### PR TITLE
if package version exists prompts to update metadata

### DIFF
--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -214,6 +214,10 @@ def main(args):
                 create_release_interactive(binstar, username, package_name, version)
             else:
                 create_release(binstar, username, package_name, version, description)
+        else:
+            print("\nPackage release already exists. Please update version number.\n")
+            raise SystemExit(-1)
+
 
         basefilename = basename(filename)
     


### PR DESCRIPTION
A simple conditional that checks if package version already exists on the binstar site. If so it prompts for version update and exits, else it works like before.
