### PR TITLE
Fix: downloading using requests should not use response.raw

### DIFF
--- a/binstar_client/__init__.py
+++ b/binstar_client/__init__.py
@@ -341,7 +341,7 @@ class Binstar(PublishMixin, CollectionsMixin, OrgMixin):
             return None
         elif res.status_code == 302:
             res2 = requests.get(res.headers['location'], stream=True, verify=True)
-            return res2.raw
+            return res2
 
 
     def upload(self, login, package_name, release, basename, fd, distribution_type,

--- a/binstar_client/commands/_files.py
+++ b/binstar_client/commands/_files.py
@@ -38,13 +38,15 @@ def main(args):
                 binstar.upload(spec.user, spec.package, spec.version, basename(file), fd, args.description, **attrs)
         print '... done'
     elif args.action == 'download':
-        fd = binstar.download(spec.user, spec.package, spec.version, spec.basename)
+        requests_handle = binstar.download(spec.user, spec.package, spec.version, spec.basename)
 
         if args.files:
             fname = args.files[0]
-        data = fd.read()
+        
         with open(fname, 'w') as fdout:
-            fdout.write(data)
+            for chunk in requests.handle.iter_content(4096):
+                fdout.write(chunk)
+            
     elif args.action == 'list':
         release = binstar.release(spec.user, spec.package, spec.version)
         for dist in release.get('distributions',[]):


### PR DESCRIPTION
Response.raw should be replaced by returning the response object and letting the caller use response.iter_content(chunk_size) to iterate over the streaming content.  
