### PR TITLE
Post all headers prepared in initialization when uploading a package

### DIFF
--- a/binstar_client/__init__.py
+++ b/binstar_client/__init__.py
@@ -408,7 +408,7 @@ class Binstar(PublishMixin, CollectionsMixin, OrgMixin, ChannelsMixin):
         data_stream, headers = stream_multipart(s3data, files={'file':(basename, fd)},
                                                 callback=callback)
 
-        s3res = requests.post(s3url, data=data_stream, verify=True, timeout=10 * 60 * 60, headers=headers)
+        s3res = self.session.post(s3url, data=data_stream, verify=True, timeout=10 * 60 * 60, headers=headers)
 
         if s3res.status_code != 201:
             log.info(s3res.text)


### PR DESCRIPTION
This change is required by feature/storage change from server server side of binstar.
Currently the code doesn't send 'x-binstar-api-version' header while uploading package,
and this is required by new 'uploads' view.
