### PR TITLE
py3k raw_input fix

### DIFF
--- a/binstar_client/utils/__init__.py
+++ b/binstar_client/utils/__init__.py
@@ -264,7 +264,7 @@ class IterableToFileAdapter(object):
 def bool_input(prompt, default=True):
         default_str = '[Y|n]' if default else '[y|N]'
         while 1:
-            inpt = raw_input('%s %s: ' % (prompt, default_str))
+            inpt = input('%s %s: ' % (prompt, default_str))
             if inpt.lower() in ['y', 'yes'] and not default:
                 return True
             elif inpt.lower() in ['', 'n', 'no'] and not default:


### PR DESCRIPTION
This is fixed slightly differently in two different places in this repository, I copied the one I thought more clear.  Encountered with the following:

(py3k)meawoppl@lisette ~/Dropbox/repos $ binstar remove meawoppl/pillow/2.4.0/linux-64/pillow-2.4.0-py33_0.tar.bz2
Traceback (most recent call last):
  File "/home/meawoppl/anaconda/envs/py3k/bin/binstar", line 6, in <module>
    sys.exit(main())
  File "/home/meawoppl/anaconda/envs/py3k/lib/python3.3/site-packages/binstar_client/scripts/cli.py", line 60, in main
    return args.main(args)
  File "/home/meawoppl/anaconda/envs/py3k/lib/python3.3/site-packages/binstar_client/commands/remove.py", line 25, in main
    if not args.force and bool_input(msg, False):
  File "/home/meawoppl/anaconda/envs/py3k/lib/python3.3/site-packages/binstar_client/utils/**init**.py", line 263, in bool_input
    inpt = raw_input('%s %s: ' % (prompt, default_str))
NameError: global name 'raw_input' is not defined
