### PR TITLE
Having an environmental variable for on premises installations

### DIFF
--- a/binstar_client/utils/__init__.py
+++ b/binstar_client/utils/__init__.py
@@ -26,8 +26,6 @@ if 'BINSTAR_CONFIG_DIR' in os.environ:
 else:
     dirs = AppDirs('binstar', 'ContinuumIO')
 
-
-
 try:
     import urlparse
     from urllib import quote_plus
@@ -247,8 +245,8 @@ def recursive_update(d, u):
             d[k] = u[k]
     return d
 
-DEFAULT_URL = 'https://api.anaconda.org'
-ALPHA_URL = 'http://api.alpha.binstar.org'
+DEFAULT_URL = os.environ.get('ANACONDA_DEFAULT_SITE', 'https://api.anaconda.org')
+ALPHA_URL = os.environ.get('ANACONDA_ALPHA_SITE', 'http://api.alpha.binstar.org')
 DEFAULT_CONFIG = {
                   'sites': {'binstar': {'url': DEFAULT_URL},
                             'alpha': {'url': ALPHA_URL},

--- a/binstar_client/utils/__init__.py
+++ b/binstar_client/utils/__init__.py
@@ -246,18 +246,23 @@ def recursive_update(d, u):
     return d
 
 DEFAULT_URL = os.environ.get('ANACONDA_DEFAULT_SITE', 'https://api.anaconda.org')
-ALPHA_URL = os.environ.get('ANACONDA_ALPHA_SITE', 'http://api.alpha.binstar.org')
+ALPHA_URL = 'http://api.alpha.binstar.org'
 DEFAULT_CONFIG = {
                   'sites': {'binstar': {'url': DEFAULT_URL},
                             'alpha': {'url': ALPHA_URL},
                             }
                   }
 
+
+def has_environment_variable_config():
+    return 'ANACONDA_DEFAULT_SITE' in os.environ
+
+
 def get_config(user=True, site=True, remote_site=None):
     config = DEFAULT_CONFIG.copy()
-    if site:
+    if not has_environment_variable_config() and site:
         recursive_update(config, load_config(SITE_CONFIG))
-    if user:
+    if not has_environment_variable_config() and user:
         recursive_update(config, load_config(USER_CONFIG))
 
     remote_site = remote_site or config.get('default_site')


### PR DESCRIPTION
In a wakari installation we want `anaconda-client` to point to the `anaconda-server` installed on premises. The only way to do this is to have **every** user updating their configuration with `anaconda config --set sites ...`.
Having an env variable will allow the administrator to configure it somewhere (we don't know yet) and we will have wakari having this env variable setup every time the user logs in.

@srossross what do you think?

@bkreider @mmarchetti @ijstokes 
