### PR TITLE
Fix encoding error in multipart io

### DIFF
--- a/binstar_client/requests_ext.py
+++ b/binstar_client/requests_ext.py
@@ -115,10 +115,10 @@ class MultiPartIO(object):
             self.callback(self.tell(), self._total)
 
         if n == -1:
-            return ''.join(fd.read() for fd in self.to_read)
+            return b''.join(fd.read() for fd in self.to_read)
 
         if not self.to_read:
-            return ''
+            return b''
 
         while self.to_read:
             data = self.to_read[0].read(n)
@@ -129,7 +129,7 @@ class MultiPartIO(object):
             fd = self.to_read.pop(0)
             self.have_read.append(fd)
 
-        return ''
+        return b''
 
     def tell(self):
         cursor = sum(fd.tell() for fd in self.have_read)

--- a/binstar_client/tests/test_requests_ext.py
+++ b/binstar_client/tests/test_requests_ext.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+import io
+import unittest
+
+from binstar_client import requests_ext
+
+
+class TestMultiPart(unittest.TestCase):
+    def test_unicode_read(self):
+        body = io.BytesIO(b'Unicode™')
+        multipart = requests_ext.MultiPartIO([body])
+        self.assertEqual(b'Unicode™', multipart.read())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/binstar_client/tests/test_requests_ext.py
+++ b/binstar_client/tests/test_requests_ext.py
@@ -7,9 +7,9 @@ from binstar_client import requests_ext
 
 class TestMultiPart(unittest.TestCase):
     def test_unicode_read(self):
-        body = io.BytesIO(b'Unicode™')
+        body = io.BytesIO(u'Unicode™'.encode('utf-8'))
         multipart = requests_ext.MultiPartIO([body])
-        self.assertEqual(b'Unicode™', multipart.read())
+        self.assertEqual(u'Unicode™'.encode('utf-8'), multipart.read())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`requests_ext.MultiPartIO` should always return bytes. 