### PR TITLE
Change package name to anaconda-client for CI

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -1,4 +1,4 @@
-package: binstar
+package: anaconda-client
 
 platform:
   - linux-32

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set data = load_setuptools()%}
 package:
-  name: binstar
+  name: anaconda-client
   version: {{data.get('version')}}
 
 build: {}


### PR DESCRIPTION
Allow us to make dev builds of anaconda-client and upload them to anaconda.org/binstar/anaconda-client. @malev 