### PR TITLE
Remove requests 2.8 warning

### DIFF
--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -19,7 +19,7 @@ import os
 from os.path import exists
 import sys
 
-from binstar_client import errors, requests_ext
+from binstar_client import errors
 from binstar_client.utils import bool_input
 from binstar_client.utils import get_server_api
 from binstar_client.utils import get_config
@@ -207,12 +207,6 @@ def upload_package(filename, package_type, aserver_api, username, args):
             log.info('Distribution already exists. Please use the '
                      '-i/--interactive or --force options or `anaconda remove %s`' % full_name)
             raise
-        except requests_ext.OpenSslError:
-            requests_ext.warn_openssl()
-            if args.show_traceback != 'never':
-                raise
-            else:
-                raise errors.BinstarError('Could not upload package')
 
         log.info("\n\nUpload(s) Complete\n")
         return [package_name, upload_info]

--- a/binstar_client/requests_ext.py
+++ b/binstar_client/requests_ext.py
@@ -11,7 +11,6 @@ import codecs
 import logging
 
 # Third party imports
-import pkg_resources
 from requests.packages.urllib3.filepost import choose_boundary, iter_fields
 from requests.packages.urllib3.packages import six
 import requests
@@ -163,36 +162,6 @@ def stream_multipart(data, files=None, callback=None):
     data = MultiPartIO(body, callback=callback)
     headers = {'Content-Type':content_type}
     return data, headers
-
-try:
-    import requests.packages.urllib3.contrib.pyopenssl
-    import OpenSSL.SSL
-except ImportError:
-    HAS_OPENSSL = False
-    OpenSslError = None
-else:
-    HAS_OPENSSL = True
-    OpenSslError = OpenSSL.SSL.Error
-
-requests_version = pkg_resources.parse_version(requests.__version__)
-
-# The first version that shipped urllib3 with issue shazow/urllib3#717
-min_requests_version = pkg_resources.parse_version('2.8')
-max_requests_version = pkg_resources.parse_version('2.9.1')
-# limit warning to broken versions
-HAS_BROKEN_URLLIB3 = min_requests_version <= requests_version < max_requests_version
-
-def warn_openssl():
-    '''
-    Output a warning about requests incompatibility
-    '''
-    if HAS_OPENSSL and HAS_BROKEN_URLLIB3:
-        log.error(
-            'The version of requests you are using is incompatible with '
-            'PyOpenSSL. Please upgrade requests to requests>=2.9.1 or '
-            'uninstall PyOpenSSL.\n'
-            'See https://github.com/anaconda-server/anaconda-client/issues/222 '
-            'for more details.')
 
 
 class NullAuth(requests.auth.AuthBase):

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -13,7 +13,7 @@ requirements:
     - python
     - setuptools
     - clyent
-    - requests
+    - requests >=2.9.1
     - pyyaml
     - dateutil
     - pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 nbformat
 PyYAML
-requests
+requests>=2.9.1
 python-dateutil
 pytz
 pillow

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description='Anaconda Cloud command line client library',
     packages=find_packages(),
     install_requires=['clyent',
-                      'requests>=2.0',
+                      'requests>=2.9.1',
                       'pyyaml',
                       'python-dateutil',
                       'pytz'],


### PR DESCRIPTION
Since a fixed version of requests has been released for several months (see https://github.com/Anaconda-Platform/anaconda-client/pull/297), we can remove this cruft.