### PR TITLE
Add license file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,25 @@
+Copyright (c) 2016, Continuum Analytics, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  * Neither the name of Continuum Analytics, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from this
+    software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL CONTINUUM ANALYTICS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -3,7 +3,14 @@ package:
   name: anaconda-client
   version: {{data.get('version')}}
 
-build: {}
+source:
+  git_url: ../
+
+build:
+  entry_points:
+    - anaconda = binstar.scripts.cli:main
+    - binstar = binstar_client.scripts.cli:main
+    - conda-server = binstar_client.scripts.cli:main
 
 requirements:
   build:
@@ -21,3 +28,6 @@ requirements:
 about:
   home: {{data.get('url')}}
   license: {{data.get('license')}}
+  license_family: BSD
+  license_file: LICENSE.md
+  summary: {{data.get('description')}}

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     cmdclass=versioneer.get_cmdclass(),
     author='Sean Ross-Ross',
     author_email='srossross@gmail.com',
-    url='http://github.com/Anaconda-client/anaconda-client',
+    url='http://github.com/Anaconda-Platform/anaconda-client',
     description='Anaconda Cloud command line client library',
     packages=find_packages(),
     install_requires=['clyent',
@@ -22,4 +22,11 @@ setup(
             'conda-server = binstar_client.scripts.cli:main'
         ]
     },
+    license='BSD License',
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Environment :: Console',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python',
+    ]
 )


### PR DESCRIPTION
Fixes #340 

Add a `LICENSE` file, plus some extra metadata to the conda and pypi packages.