### PR TITLE
change to help text

### DIFF
--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -280,7 +280,7 @@ def add_parser(subparsers):
     parser.add_argument('-l', '--label', action='append', dest='labels',
                         help=label_help.format(deprecation='', label='label'))
     parser.add_argument('--no-progress', help="Don't show upload progress", action='store_true')
-    parser.add_argument('-u', '--user', help='User account, defaults to the current user')
+    parser.add_argument('-u', '--user', help='User account or Organization, defaults to the current user')
 
     mgroup = parser.add_argument_group('metadata options')
     mgroup.add_argument('-p', '--package', help='Defaults to the package name in the uploaded file')


### PR DESCRIPTION
Adding clarity in help text to denote that -u can be used for
organiziations as well.