### PR TITLE
Load configuration from $PREFIX/.anacondarc

### DIFF
--- a/binstar_client/commands/config.py
+++ b/binstar_client/commands/config.py
@@ -69,7 +69,7 @@ import logging
 from binstar_client.errors import ShowHelp, UserError
 import yaml
 from binstar_client.utils.config import (SEARCH_PATH, USER_CONFIG, SYSTEM_CONFIG, CONFIGURATION_KEYS,
-                                         get_config, set_config, load_config, load_file_configs)
+                                         get_config, save_config, load_config, load_file_configs)
 log = logging.getLogger('binstar.config')
 
 def recursive_set(config_data, key, value, ty):
@@ -134,7 +134,7 @@ def main(args):
     if not (args.set or args.remove):
         raise ShowHelp()
 
-    set_config(config, config_file)
+    save_config(config, config_file)
 
 
 def add_parser(subparsers):

--- a/binstar_client/commands/config.py
+++ b/binstar_client/commands/config.py
@@ -66,12 +66,10 @@ from argparse import RawDescriptionHelpFormatter
 from ast import literal_eval
 import logging
 
-from binstar_client.errors import ShowHelp
-from binstar_client.utils import get_config, set_config, SITE_CONFIG, \
-    USER_CONFIG
+from binstar_client.errors import ShowHelp, UserError
 import yaml
-
-
+from binstar_client.utils.config import (SEARCH_PATH, USER_CONFIG, SYSTEM_CONFIG, CONFIGURATION_KEYS,
+                                         get_config, set_config, load_config, load_file_configs)
 log = logging.getLogger('binstar.config')
 
 def recursive_set(config_data, key, value, ty):
@@ -79,6 +77,8 @@ def recursive_set(config_data, key, value, ty):
         prefix, key = key.split('.', 1)
         config_data = config_data.setdefault(prefix, {})
 
+    if key not in CONFIGURATION_KEYS:
+        log.warn('"%s" is not a known configuration key', key)
     config_data[key] = ty(value)
 
 def recursive_remove(config_data, key):
@@ -96,15 +96,14 @@ def main(args):
     config = get_config()
 
     if args.show:
-        fmt = ' + %s: %r'
-        log.info('Site Config: %s' % SITE_CONFIG)
-        for key_value in get_config(user=False).items():
-            log.info(fmt % key_value)
-        log.info("")
-        log.info('User Config: %s' % USER_CONFIG)
-        for key_value in get_config(site=False).items():
-            log.info(fmt % key_value)
-        log.info("")
+        log.info(yaml.safe_dump(config, default_flow_style=False))
+        return
+
+    if args.show_sources:
+        config_files = load_file_configs(SEARCH_PATH)
+        for path in config_files:
+            log.info('==> %s <==', path)
+            log.info(yaml.safe_dump(config_files[path], default_flow_style=False))
         return
 
     if args.get:
@@ -116,14 +115,15 @@ def main(args):
 
     if args.files:
         log.info('User Config: %s' % USER_CONFIG)
-        log.info('Site Config: %s' % SITE_CONFIG)
+        log.info('System Config: %s' % SYSTEM_CONFIG)
         return
 
-    config = get_config(args.user, not args.user)
+    config_file = USER_CONFIG if args.user else SYSTEM_CONFIG
+
+    config = load_config(config_file)
 
     for key, value in args.set:
         recursive_set(config, key, value, args.type)
-        config[key] = args.type(value)
 
     for key in args.remove:
         try:
@@ -134,11 +134,11 @@ def main(args):
     if not (args.set or args.remove):
         raise ShowHelp()
 
-    set_config(config, args.user)
+    set_config(config, config_file)
 
 
 def add_parser(subparsers):
-    description = 'Binstar configuration'
+    description = 'Anaconda client configuration'
     parser = subparsers.add_parser('config',
                                       help=description,
                                       description=description,
@@ -161,10 +161,12 @@ def add_parser(subparsers):
                         help='show all variables')
     agroup.add_argument('-f', '--files', action='store_true',
                         help='show the config file names')
+    agroup.add_argument('--show-sources', action='store_true',
+                        help='Display all identified config sources')
     lgroup = parser.add_argument_group('location')
     lgroup.add_argument('-u', '--user', action='store_true', dest='user', default=True,
                         help='set a variable for this user')
-    lgroup.add_argument('-s', '--site', action='store_false', dest='user',
+    lgroup.add_argument('-s', '--system', '--site', action='store_false', dest='user',
                         help='set a variable for all users on this machine')
 
 

--- a/binstar_client/utils/conda.py
+++ b/binstar_client/utils/conda.py
@@ -1,0 +1,39 @@
+from os.path import basename, dirname, join
+import json
+import sys
+import subprocess
+
+CONDA_PREFIX = sys.prefix
+BIN_DIR = 'Scripts' if sys.platform.startswith('win') else 'bin'
+CONDA_EXE = join(CONDA_PREFIX, BIN_DIR, 'conda')
+
+
+def get_conda_root():
+    """Get the PREFIX of the conda installation.
+
+    Returns:
+        str: the ROOT_PREFIX of the conda installation
+    """
+    try:
+        # Fast-path
+        # We're in the root environment
+        import conda.config
+        conda_root = conda.config.root_dir
+    except ImportError:
+        # We're not in the root environment.
+        envs_dir = dirname(CONDA_PREFIX)
+        if basename(envs_dir) == 'envs':
+            # We're in a named environment: `conda create -n <name>`
+            conda_root = dirname(envs_dir)
+        else:
+            # We're in an isolated environment: `conda create -p <path>`
+            # The only way we can find out is by calling conda.
+            try:
+                conda_info = json.loads(subprocess.check_output([CONDA_EXE, 'info', '--json']))
+                conda_root = conda_info['root_prefix']
+            except (ValueError, KeyError, subprocess.CalledProcessError):
+                conda_root = None
+
+    return conda_root
+
+CONDA_ROOT = get_conda_root()

--- a/binstar_client/utils/config.py
+++ b/binstar_client/utils/config.py
@@ -19,6 +19,7 @@ except ImportError:
 
 import yaml
 
+from binstar_client.utils.conda import CONDA_PREFIX, CONDA_ROOT
 from binstar_client.utils.appdirs import AppDirs, EnvAppDirs
 from binstar_client.errors import BinstarError
 
@@ -29,28 +30,6 @@ if 'BINSTAR_CONFIG_DIR' in os.environ:
     dirs = EnvAppDirs('binstar', 'ContinuumIO', os.environ['BINSTAR_CONFIG_DIR'])
 else:
     dirs = AppDirs('binstar', 'ContinuumIO')
-
-CONDA_PREFIX = sys.prefix
-try:
-    # We're in the root environment
-    import conda.config
-    CONDA_ROOT = conda.config.root_dir
-except ImportError:
-    # We're not in the root environment.
-    envs_dir = dirname(CONDA_PREFIX)
-    if basename(envs_dir) == 'envs':
-        # We're in a named environment: `conda create -n <name>`
-        CONDA_ROOT = dirname(envs_dir)
-    else:
-        # We're in an isolated environment: `conda create -p <path>`
-        # TODO: shell out to $PREFIX/bin/conda?
-        # CONDA_EXE = join(dirname(sys.executable), 'conda')
-        # import subprocess
-
-        #     conda_info = json.loads(subprocess.check_output([CONDA_EXE, 'info', '--json']))
-        #     CONDA_ROOT = conda_info['root_prefix']
-        # except (KeyError, subprocess.CalledProcessError):
-            CONDA_ROOT = None
 
 USER_LOGDIR = dirs.user_log_dir
 

--- a/binstar_client/utils/config.py
+++ b/binstar_client/utils/config.py
@@ -53,7 +53,6 @@ SEARCH_PATH = (
     dirs.user_data_dir,
     '~/.continuum/anaconda-client/',
     '$CONDA_PREFIX/etc/anaconda-client/',
-    '$ANACONDARC',
 )
 
 

--- a/binstar_client/utils/test/test_config.py
+++ b/binstar_client/utils/test/test_config.py
@@ -1,0 +1,66 @@
+from os.path import join
+import os
+import unittest
+import inspect
+import shutil
+import tempfile
+
+import mock
+
+from binstar_client.utils import config
+
+
+class Test(unittest.TestCase):
+    def test_signature(self):
+        from binstar_client.utils import get_config, set_config
+
+        # make sure that our exported methods have the same interface
+        spec = inspect.getargspec(get_config)
+        self.assertEqual(spec.args, ['user', 'site', 'remote_site'])
+        self.assertEqual(spec.defaults, (True, True, None))
+
+        spec = inspect.getargspec(set_config)
+        self.assertEqual(spec.args, ['data', 'user'])
+        self.assertEqual(spec.defaults, (True,))
+
+    def test_merge(self):
+        tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmpdir)
+
+        system_dir = join(tmpdir, 'system')
+        user_dir = join(tmpdir, 'user')
+        os.mkdir(system_dir)
+        os.mkdir(user_dir)
+
+        with open(join(system_dir, 'config.yaml'), 'wb') as fd:
+            fd.write(b'''
+ssl_verify: false
+sites:
+    develop:
+        url: http://develop.anaconda.org
+            ''')
+
+        with open(join(user_dir, 'config.yaml'), 'wb') as fd:
+            fd.write(b'''
+ssl_verify: true
+sites:
+    develop:
+        ssl_verify: false
+            ''')
+
+
+        with mock.patch('binstar_client.utils.config.SEARCH_PATH', [system_dir, user_dir]), \
+                mock.patch('binstar_client.utils.config.DEFAULT_CONFIG', {}):
+            cfg = config.get_config()
+
+            self.assertEqual(cfg, {
+                'ssl_verify': True,
+                'sites': {
+                    'develop': {
+                        'url': 'http://develop.anaconda.org',
+                        'ssl_verify': False,
+                    }
+                }
+            })
+
+


### PR DESCRIPTION
https://github.com/Anaconda-Platform/anaconda-server/issues/2826
https://github.com/Anaconda-Platform/anaconda-server/issues/2516

Allows `anaconda-client` to load configuration files from the conda prefix/root prefix.