### PR TITLE
Finding conda root, decode the `conda info` output before JSON-parsing

### DIFF
--- a/binstar_client/utils/test/test_conda.py
+++ b/binstar_client/utils/test/test_conda.py
@@ -1,0 +1,32 @@
+import os
+
+from binstar_client.utils import conda
+
+
+def test_conda_root():
+    from binstar_client.utils.conda import get_conda_root
+
+    assert get_conda_root() is not None
+
+
+def test_conda_root_outside_root_environment(monkeypatch):
+    called_mock = { 'called' : False }
+    def mock_import_conda_root():
+        called_mock['called'] = True
+        raise ImportError("did not import it")
+
+    monkeypatch.setattr('binstar_client.utils.conda._import_conda_root', mock_import_conda_root)
+
+    from binstar_client.utils.conda import get_conda_root
+
+    assert get_conda_root() is not None
+
+    assert called_mock['called']
+
+
+def test_conda_root_from_conda_info(monkeypatch):
+    from binstar_client.utils.conda import _conda_root_from_conda_info
+
+    conda_root = _conda_root_from_conda_info()
+    assert conda_root is not None
+    assert os.path.isdir(conda_root)


### PR DESCRIPTION
This crashed on Python 3 in an environment outside of envs/ directory,
which unfortunately happens during a conda package build.