### PR TITLE
Fix/download non notebook files

### DIFF
--- a/binstar_client/commands/download.py
+++ b/binstar_client/commands/download.py
@@ -61,4 +61,4 @@ def main(args):
             log.info("    conda env create {}".format(download_info[0]))
             log.info("To install the environment in your system")
     except (errors.DestionationPathExists, errors.NotFound, errors.BinstarError, OSError) as err:
-        log.info(err.msg)
+        log.info(err)

--- a/binstar_client/utils/notebook/__init__.py
+++ b/binstar_client/utils/notebook/__init__.py
@@ -42,6 +42,9 @@ def notebook_url(upload_info):
 
 
 def has_environment(nb_file):
+    if nbformat is None:
+        return False
+
     try:
         with open(nb_file) as fb:
             data = fb.read()
@@ -50,4 +53,4 @@ def has_environment(nb_file):
     except (AttributeError, KeyError):
         return False
     except (IOError, nbformat.reader.NotJSONError):
-        raise BinstarError("Unable to open {}.".format(nb_file))
+        return False

--- a/binstar_client/utils/notebook/downloader.py
+++ b/binstar_client/utils/notebook/downloader.py
@@ -32,10 +32,19 @@ class Downloader(object):
         """
         Download file into location
         """
-        requests_handle = self.aserver_api.download(self.username, self.notebook,
-                                                dist['version'], dist['basename'])
+        filename = dist['basename']
+        requests_handle = self.aserver_api.download(
+            self.username, self.notebook, dist['version'], filename
+        )
 
-        with open(os.path.join(self.output, dist['basename']), 'wb') as fdout:
+        if not os.path.exists(os.path.dirname(filename)):
+            try:
+                os.makedirs(os.path.dirname(filename))
+            except OSError as exc: # Guard against race condition
+                if exc.errno != errno.EEXIST:
+                    raise
+
+        with open(os.path.join(self.output, filename), 'wb') as fdout:
             for chunk in requests_handle.iter_content(4096):
                 fdout.write(chunk)
 

--- a/binstar_client/utils/notebook/downloader.py
+++ b/binstar_client/utils/notebook/downloader.py
@@ -40,7 +40,7 @@ class Downloader(object):
         if not os.path.exists(os.path.dirname(filename)):
             try:
                 os.makedirs(os.path.dirname(filename))
-            except:
+            except OSError:
                 pass
 
         with open(os.path.join(self.output, filename), 'wb') as fdout:

--- a/binstar_client/utils/notebook/downloader.py
+++ b/binstar_client/utils/notebook/downloader.py
@@ -40,9 +40,8 @@ class Downloader(object):
         if not os.path.exists(os.path.dirname(filename)):
             try:
                 os.makedirs(os.path.dirname(filename))
-            except OSError as exc: # Guard against race condition
-                if exc.errno != errno.EEXIST:
-                    raise
+            except:
+                pass
 
         with open(os.path.join(self.output, filename), 'wb') as fdout:
             for chunk in requests_handle.iter_content(4096):

--- a/binstar_client/utils/notebook/tests/test_base.py
+++ b/binstar_client/utils/notebook/tests/test_base.py
@@ -37,8 +37,7 @@ class HasEnvironmentTestCase(unittest.TestCase):
         assert has_environment(self.data_dir('notebook_with_env.ipynb'))
 
     def test_no_file(self):
-        with self.assertRaises(BinstarError):
-            has_environment("no-file")
+        self.assertFalse(has_environment("no-file"))
 
 
 if __name__ == '__main__':

--- a/binstar_client/utils/test/test_conda.py
+++ b/binstar_client/utils/test/test_conda.py
@@ -1,4 +1,5 @@
 import os
+import mock
 
 from binstar_client.utils import conda
 
@@ -9,22 +10,20 @@ def test_conda_root():
     assert get_conda_root() is not None
 
 
-def test_conda_root_outside_root_environment(monkeypatch):
-    called_mock = { 'called' : False }
-    def mock_import_conda_root():
-        called_mock['called'] = True
+@mock.patch('binstar_client.utils.conda._import_conda_root')
+def test_conda_root_outside_root_environment(mock_import_conda_root):
+    def _import_conda_root():
         raise ImportError("did not import it")
 
-    monkeypatch.setattr('binstar_client.utils.conda._import_conda_root', mock_import_conda_root)
-
+    mock_import_conda_root.side_effect = _import_conda_root
     from binstar_client.utils.conda import get_conda_root
 
     assert get_conda_root() is not None
 
-    assert called_mock['called']
+    assert mock_import_conda_root.called
 
 
-def test_conda_root_from_conda_info(monkeypatch):
+def test_conda_root_from_conda_info():
     from binstar_client.utils.conda import _conda_root_from_conda_info
 
     conda_root = _conda_root_from_conda_info()


### PR DESCRIPTION
Closes #336 

This fixes the issue about downloading non-notebook files using the `download` command but the command was not intended to do that.

Also i filed issue #385 to be able to determine which file will be downloaded. Adding support for package version would be great too.