### PR TITLE
Better error message for the server not found exception

### DIFF
--- a/binstar_client/__init__.py
+++ b/binstar_client/__init__.py
@@ -63,6 +63,22 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
     def session(self):
         return self._session
 
+    def check_server(self):
+        """
+        Checks if the server is reachable and throws
+        and exception if it isn't
+        """
+        msg = 'API server not found. Please check your API url configuration.'
+
+        try:
+            res = self.session.head(self.domain)
+        except:
+            raise errors.NotFound(msg)
+        try:
+            self._check_response(res)
+        except errors.NotFound:
+            raise errors.NotFound(msg)
+
     def authentication_type(self):
         url = '%s/authentication-type' % self.domain
         res = self.session.get(url)
@@ -70,8 +86,6 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
             self._check_response(res)
             res = res.json()
             return res['authentication_type']
-        except errors.NotFound:
-            raise errors.NotFound('API server not found. Please check your API url configuration.')
         except BinstarError:
             return 'password'
 

--- a/binstar_client/__init__.py
+++ b/binstar_client/__init__.py
@@ -70,6 +70,8 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
             self._check_response(res)
             res = res.json()
             return res['authentication_type']
+        except errors.NotFound:
+            raise errors.NotFound('API server not found. Please check your API url configuration.')
         except BinstarError:
             return 'password'
 

--- a/binstar_client/commands/login.py
+++ b/binstar_client/commands/login.py
@@ -65,6 +65,7 @@ def interactive_get_token(args, fail_if_already_exists=True):
 
     auth_name += '%s@%s' % (getpass.getuser(), hostname)
 
+    bs.check_server()
     auth_type = bs.authentication_type()
 
     if auth_type == 'kerberos':

--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -215,6 +215,7 @@ def upload_package(filename, package_type, aserver_api, username, args):
 def main(args):
 
     aserver_api = get_server_api(args.token, args.site, args.log_level)
+    aserver_api.check_server()
 
     if args.user:
         username = args.user

--- a/binstar_client/tests/test_login.py
+++ b/binstar_client/tests/test_login.py
@@ -28,6 +28,7 @@ class Test(CLITestCase):
         input.return_value = 'test_user'
         getpass.return_value = 'password'
 
+        urls.register(path='/', method='HEAD', status=200)
         urls.register(path='/authentication-type', content='{"authentication_type": "password"}')
 
         auth = urls.register(method='POST', path='/authentications', content='{"token": "a-token"}')
@@ -50,6 +51,7 @@ class Test(CLITestCase):
         input.return_value = 'test_user'
         getpass.return_value = 'password'
 
+        urls.register(path='/', method='HEAD', status=200)
         urls.register(path='/authentication-type', status=404)
 
         auth = urls.register(method='POST', path='/authentications', content='{"token": "a-token"}')
@@ -67,6 +69,7 @@ class Test(CLITestCase):
     @unittest.skipIf(have_kerberos, "prompts user to install requests-kerberos")
     @urlpatch
     def test_login_kerberos_missing(self, urls):
+        urls.register(path='/', method='HEAD', status=200)
         urls.register(path='/authentication-type', content='{"authentication_type": "kerberos"}')
 
         with self.assertRaisesRegexp(errors.BinstarError, 'conda install requests-kerberos'):
@@ -77,6 +80,7 @@ class Test(CLITestCase):
     @urlpatch
     def test_login_kerberos(self, urls, store_token):
 
+        urls.register(path='/', method='HEAD', status=200)
         urls.register(path='/authentication-type', content='{"authentication_type": "kerberos"}')
 
         def update_authentications():

--- a/binstar_client/tests/test_upload.py
+++ b/binstar_client/tests/test_upload.py
@@ -17,6 +17,7 @@ class Test(CLITestCase):
     @urlpatch
     def test_upload_bad_package(self, registry):
 
+        registry.register(method='HEAD', path='/', status=200)
         registry.register(method='GET', path='/user', content='{"login": "eggs"}')
         registry.register(method='GET', path='/package/eggs/foo', content='{}', status=404)
         registry.register(method='POST', path='/package/eggs/foo', content='{}', status=200)
@@ -37,6 +38,7 @@ class Test(CLITestCase):
     @urlpatch
     def test_upload_bad_package_no_register(self, registry):
 
+        registry.register(method='HEAD', path='/', status=200)
         registry.register(method='GET', path='/user', content='{"login": "eggs"}')
         registry.register(method='GET', path='/package/eggs/foo', status=404)
 
@@ -48,6 +50,7 @@ class Test(CLITestCase):
     @urlpatch
     def test_upload_conda(self, registry):
 
+        registry.register(method='HEAD', path='/', status=200)
         registry.register(method='GET', path='/user', content='{"login": "eggs"}')
         registry.register(method='GET', path='/package/eggs/foo', content='{}')
         registry.register(method='GET', path='/release/eggs/foo/0.1', content='{}')
@@ -66,6 +69,7 @@ class Test(CLITestCase):
     @urlpatch
     def test_upload_pypi(self, registry):
 
+        registry.register(method='HEAD', path='/', status=200)
         registry.register(method='GET', path='/user', content='{"login": "eggs"}')
         registry.register(method='GET', path='/package/eggs/test-package34', content='{}')
         registry.register(method='GET', path='/release/eggs/test-package34/0.3.1', content='{}')
@@ -83,6 +87,7 @@ class Test(CLITestCase):
 
     @urlpatch
     def test_upload_file(self, registry):
+        registry.register(method='HEAD', path='/', status=200)
         registry.register(method='GET', path='/user', content='{"login": "eggs"}')
         registry.register(method='GET', path='/package/eggs/test-package34', content='{}')
         registry.register(method='GET', path='/release/eggs/test-package34/0.3.1', content='{}')
@@ -107,6 +112,7 @@ class Test(CLITestCase):
         # there's redundant work between anaconda-client which
         # checks auth and anaconda-project also checks auth;
         # -project has no way to know it was already checked :-/
+        registry.register(method='HEAD', path='/', status=200)
         registry.register(method='GET', path='/user/eggs', content='{"login": "eggs"}')
         registry.register(method='GET', path='/user', content='{"login": "eggs"}')
         registry.register(method='GET', path='/apps/eggs/projects/dog', content='{}')
@@ -124,6 +130,7 @@ class Test(CLITestCase):
 
     @urlpatch
     def test_upload_notebook_as_project(self, registry):
+        registry.register(method='HEAD', path='/', status=200)
         registry.register(method='GET', path='/user/eggs', content='{"login": "eggs"}')
         registry.register(method='GET', path='/user', content='{"login": "eggs"}')
         registry.register(method='GET', path='/apps/eggs/projects/foo', content='{}')
@@ -141,6 +148,7 @@ class Test(CLITestCase):
 
     @urlpatch
     def test_upload_project_specifying_user(self, registry):
+        registry.register(method='HEAD', path='/', status=200)
         registry.register(method='GET', path='/user/alice', content='{"login": "alice"}')
         registry.register(method='GET', path='/apps/alice/projects/dog', content='{}')
         stage_content = '{"post_url":"http://s3url.com/s3_url", "form_data":{"foo":"bar"}, "dist_id":"dist42"}'
@@ -159,6 +167,7 @@ class Test(CLITestCase):
 
     @urlpatch
     def test_upload_project_specifying_token(self, registry):
+        registry.register(method='HEAD', path='/', status=200)
         registry.register(method='GET', path='/user/eggs', content='{"login": "eggs"}',
                           expected_headers={'Authorization':'token abcdefg'})
         registry.register(method='GET', path='/user', content='{"login": "eggs"}')
@@ -180,6 +189,7 @@ class Test(CLITestCase):
     @patch('binstar_client.commands.upload.bool_input')
     def test_upload_interactive_no_overwrite(self, registry, bool_input):
         # regression test for #364
+        registry.register(method='HEAD', path='/', status=200)
         registry.register(method='GET', path='/user', content='{"login": "eggs"}')
         registry.register(method='GET', path='/package/eggs/foo', content='{}')
         registry.register(method='GET', path='/release/eggs/foo/0.1', content='{}')


### PR DESCRIPTION
Closes #206 and #207 

Just displays a custom message when the api server returns a 404. Looks like this now:

<img width="618" alt="screen shot 2017-02-14 at 11 23 59 am" src="https://cloud.githubusercontent.com/assets/172606/22932988/d09eb976-f2a8-11e6-8539-d528dadb36d9.png">
