### PR TITLE
Feat/send about fields

### DIFF
--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -123,7 +123,8 @@ def add_package(aserver_api, args, username, package_name, package_attrs, packag
                 summary,
                 package_attrs.get('license'),
                 public=True,
-                attrs=package_attrs
+                attrs=package_attrs,
+                license_url=package_attrs.get('license_url')
             )
 
 

--- a/binstar_client/inspect_package/conda.py
+++ b/binstar_client/inspect_package/conda.py
@@ -136,17 +136,17 @@ def inspect_conda_package(filename, fileobj, *args, **kwargs):
         'doc_url': about.get('doc_url'),
         'home': about.get('home'),
         'source_git_url': about.get('source_git_url'),
-        'source_git_tag': about.get('source_git_tag'),
-        }
+    }
     release_data = {
         'version': index.pop('version'),
         'home_page': about.get('home'),
         'description': about.get('description', ''),
+        'source_git_tag': about.get('source_git_tag'),
         # TODO: Add summary and license as per release attributes
         # 'summary': about.get('summary', ''),
         # 'license': about.get('license'),
         'icon': icon_b64,
-        }
+    }
     file_data = {
         'basename': '%s/%s' % (subdir, path.basename(filename)),
         'attrs': {
@@ -154,8 +154,8 @@ def inspect_conda_package(filename, fileobj, *args, **kwargs):
             'machine': machine,
             'target-triplet': '%s-any-%s' % (machine, operatingsystem),
             'has_prefix': has_prefix
-            }
         }
+    }
 
     file_data['attrs'].update(index)
     conda_depends = index.get('depends', index.get('requires', []))

--- a/binstar_client/inspect_package/tests/test_conda.py
+++ b/binstar_client/inspect_package/tests/test_conda.py
@@ -21,12 +21,12 @@ expected_package_data = {
     'license': None,
     'license_url': None,
     'source_git_url': None,
-    'source_git_tag': None,
     'name': 'conda_gc_test',
     'summary': 'This is a simple meta-package',
 }
 
 expected_version_data_121 = {
+    'source_git_tag': None,
     'description': '',
     'home_page': None,
     'icon': None,  # The icon if found on the conda folder is uplaoded here.
@@ -34,6 +34,7 @@ expected_version_data_121 = {
 }
 
 expected_version_data_221 = {
+    'source_git_tag': None,
     'description': '',
     'home_page': None,
     'icon': None,  # The icon if found on the conda folder is uplaoded here.
@@ -90,7 +91,6 @@ app_expected_package_data = {
     'description': 'test description',
     'dev_url': 'https://dev.url',
     'doc_url': 'https://doc.url',
-    'source_git_tag': 0.1,
     'source_git_url': 'http://git.url',
     'license': 'LICENSE',
     'license_url': 'http://license.url',
@@ -99,6 +99,7 @@ app_expected_package_data = {
     }
 
 app_expected_version_data = {
+    'source_git_tag': 0.1,
     'description': 'test description',
     'home_page': 'http://home.page',
     'icon': ICON_B64,


### PR DESCRIPTION
Removes git tag from the metadata fields of the package and sends it as a release metadata.