### PR TITLE
Put some JSON in test notebook foo.ipynb

### DIFF
--- a/binstar_client/tests/data/foo.ipynb
+++ b/binstar_client/tests/data/foo.ipynb
@@ -1,0 +1,1 @@
+{"cells": [{"cell_type": "code", "source": ["print('hi')\n"]}]}


### PR DESCRIPTION
Latest anaconda_project gets upset about an empty notebook file
because it pokes in the notebook file for information.

(This is supposed to fix the build)