### PR TITLE
add pip install info

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,22 @@ First create an account on [Anaconda Cloud](https://anaconda.org)
 
 ### Install the client:
 
-#### With Conda:
+#### With Conda (recommended):
 
 ```
 $ conda install anaconda-client
+```
+
+#### With pip:
+
+```
+pip install anaconda-client
+```
+
+#### With pip from source:
+
+```
+pip install git+https://github.com/Anaconda-Server/anaconda-client
 ```
 
 ### Login


### PR DESCRIPTION
We are about to edit https://docs.continuum.io/anaconda-repository/user/using so that it only shows the conda installation method. @abarto suggested having the alternate methods in the readme here but not on that docs page.