### PR TITLE
trying with conda.bat if conda.exe doesn't exists

### DIFF
--- a/binstar_client/utils/conda.py
+++ b/binstar_client/utils/conda.py
@@ -1,4 +1,4 @@
-from os.path import basename, dirname, join
+from os.path import basename, dirname, join, exists
 import json
 import sys
 import subprocess
@@ -6,8 +6,8 @@ import subprocess
 WINDOWS = sys.platform.startswith('win')
 CONDA_PREFIX = sys.prefix
 BIN_DIR = 'Scripts' if WINDOWS else 'bin'
-CONDA_EXE = join(CONDA_PREFIX, BIN_DIR,
-                 'conda.exe' if WINDOWS else 'conda')
+CONDA_EXE = join(CONDA_PREFIX, BIN_DIR, 'conda.exe' if WINDOWS else 'conda')
+CONDA_BAT = join(CONDA_PREFIX, BIN_DIR, 'conda.bat')
 
 
 # this function is broken out for monkeypatch by unit tests,
@@ -19,7 +19,11 @@ def _import_conda_root():
 
 def _conda_root_from_conda_info():
     try:
-        output = subprocess.check_output([CONDA_EXE, 'info', '--json']).decode("utf-8")
+        command = CONDA_EXE
+        if WINDOWS:
+            command = CONDA_EXE if exists(CONDA_EXE) else CONDA_BAT
+
+        output = subprocess.check_output([command, 'info', '--json']).decode("utf-8")
         conda_info = json.loads(output)
         return conda_info['root_prefix']
     except (ValueError, KeyError, subprocess.CalledProcessError):

--- a/binstar_client/utils/conda.py
+++ b/binstar_client/utils/conda.py
@@ -17,12 +17,22 @@ def _import_conda_root():
     return conda.config.root_dir
 
 
-def _conda_root_from_conda_info():
-    try:
-        command = CONDA_EXE
-        if WINDOWS:
-            command = CONDA_EXE if exists(CONDA_EXE) else CONDA_BAT
+def _get_conda_exe():
+    command = CONDA_EXE
+    if WINDOWS:
+        command = CONDA_EXE if exists(CONDA_EXE) else CONDA_BAT
 
+    if not exists(command):
+        command = None
+
+    return command
+
+def _conda_root_from_conda_info():
+    command = _get_conda_exe()
+    if not command:
+        return None
+
+    try:
         output = subprocess.check_output([command, 'info', '--json']).decode("utf-8")
         conda_info = json.loads(output)
         return conda_info['root_prefix']


### PR DESCRIPTION
Fixes #398 

Conda build creates a `conda.bat` that works as a symlink to a `conda.exe`. What i did is check which one exists and use that.