### PR TITLE
Add `https://` to domain URL when is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG:
 
+## Next Release
+
+### Added
+
+* Add `https://` to domain URL when is missing
+
 ## Version 1.6.3 (2017/04/24)
 
 ### Issues Closed

--- a/binstar_client/__init__.py
+++ b/binstar_client/__init__.py
@@ -57,6 +57,8 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
 
         if domain.endswith('/'):
             domain = domain[:-1]
+        if not domain.startswith(('http://', 'https://')):
+            domain = 'https://' + domain
         self.domain = domain
 
     @property


### PR DESCRIPTION
Solves https://github.com/Anaconda-Platform/anaconda-server/issues/3000 adding `https://` when   necessary to domain