### PR TITLE
Fixed missing description issue

### DIFF
--- a/binstar_client/__init__.py
+++ b/binstar_client/__init__.py
@@ -411,6 +411,7 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
         payload = {
             'requirements': requirements,
             'announce': announce,
+            'description': None,  # Will be updated with the one on release_attrs
         }
         payload.update(release_attrs)
 


### PR DESCRIPTION
When adding a release we need to be sure we're sending a description, even if it's None. This PR fixes the case where `release_attrs` doesn't have `description`