### PR TITLE
Added warning message if server returns token warning

### DIFF
--- a/binstar_client/__init__.py
+++ b/binstar_client/__init__.py
@@ -44,6 +44,7 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
         self.session.verify = verify
         self.session.auth = NullAuth()
         self.token = token
+        self._token_warning_sent = False
 
         user_agent = 'Anaconda-Client/{} (+https://anaconda.org)'.format(__version__)
         self._session.headers.update({
@@ -194,6 +195,10 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
                    + 'Please update your client with pip install -U binstar or conda update binstar')
             warnings.warn(msg, stacklevel=4)
 
+        if not self._token_warning_sent and 'Conda-Token-Warning' in res.headers:
+            msg = 'Token warning: {}'.format(res.headers['Conda-Token-Warning'])
+            warnings.warn(msg, stacklevel=4)
+            self._token_warning_sent = True
 
         if not res.status_code in allowed:
             short, long = STATUS_CODES.get(res.status_code, ('?', 'Undefined error'))

--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -253,7 +253,6 @@ def get_convert_files(files):
 
 
 def main(args):
-
     aserver_api = get_server_api(args.token, args.site, args.log_level)
     aserver_api.check_server()
 


### PR DESCRIPTION
When the token is about to expire, the server returns a header announcing that. This PR displays a warning message when that happens.

Closes #91 