### PR TITLE
sending package_types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG:
 
+# Next Release
+
+### Fixed
+
+* Using seconds on environment version
+* Sending package_type field on upload
+
 ## Version 1.6.5 (2017/09/08)
 
 ### Fixed

--- a/binstar_client/__init__.py
+++ b/binstar_client/__init__.py
@@ -330,7 +330,8 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
                     public=True,
                     license_url=None,
                     license_family=None,
-                    attrs=None):
+                    attrs=None,
+                    package_type=None):
         '''
         Add a new package to a users account
 
@@ -347,6 +348,7 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
 
         attrs = attrs or {}
         attrs['summary'] = summary
+        attrs['package_types'] = [package_type]
         attrs['license'] = {
             'name': license,
             'url': license_url,

--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -143,7 +143,8 @@ def add_package(aserver_api, args, username, package_name, package_attrs, packag
                 public=public,
                 attrs=package_attrs,
                 license_url=package_attrs.get('license_url'),
-                license_family=package_attrs.get('license_family')
+                license_family=package_attrs.get('license_family'),
+                package_type=package_type,
             )
 
 


### PR DESCRIPTION
When uploading a package we need to send the `package_types` attribute.