### PR TITLE
Using session to upload a package when the storage is in the same server as the api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Display correct file type when uploading
 * Refactor of `data_dir`/`data_path` function
 * Fixed token generation when server uses Kerberos authentication
+* Using session to upload packages when the storage is in the same server as the API
 
 ## Version 1.6.5 (2017/09/08)
 

--- a/binstar_client/__init__.py
+++ b/binstar_client/__init__.py
@@ -533,7 +533,12 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
         data_stream, headers = stream_multipart(s3data, files={'file':(basename, fd)},
                                                 callback=callback)
 
-        s3res = requests.post(s3url, data=data_stream, verify=self.session.verify, timeout=10 * 60 * 60, headers=headers)
+        request_method = self.session if s3url.startswith(self.domain) else requests
+        s3res = request_method.post(
+            s3url, data=data_stream,
+            verify=self.session.verify, timeout=10 * 60 * 60,
+            headers=headers
+        )
 
         if s3res.status_code != 201:
             log.info(s3res.text)


### PR DESCRIPTION
We weren't sending the proper headers when the storage is located in the same server as the API.