### PR TITLE
Using ssl_verify option as an alternative to verify_ssl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Next Release
 
+### Added
+* Deprecated verify_ssl in favor of ssl_verify
+
 ### Fixed
 
 * Using seconds on environment version

--- a/binstar_client/commands/config.py
+++ b/binstar_client/commands/config.py
@@ -48,8 +48,8 @@ prefix the option with `sites.site_name` e.g.
 ###### Common anaconda-client configuration options
 
   * `url`: Set the anaconda api url (default: https://api.anaconda.org)
-  * `verify_ssl`: Perform ssl validation on the https requests.
-    verify_ssl may be `True`, `False` or a path to a root CA pem file.
+  * `ssl_verify`: Perform ssl validation on the https requests.
+    ssl_verify may be `True`, `False` or a path to a root CA pem file.
 
 
 ###### Toggle auto_register when doing anaconda upload

--- a/binstar_client/commands/config.py
+++ b/binstar_client/commands/config.py
@@ -72,6 +72,11 @@ from binstar_client.utils.config import (SEARCH_PATH, USER_CONFIG, SYSTEM_CONFIG
                                          get_config, save_config, load_config, load_file_configs)
 log = logging.getLogger('binstar.config')
 
+DEPRECATED = {
+    'verify_ssl': 'Please use ssl_verify instead'
+}
+
+
 def recursive_set(config_data, key, value, ty):
     while '.' in key:
         prefix, key = key.split('.', 1)
@@ -79,6 +84,11 @@ def recursive_set(config_data, key, value, ty):
 
     if key not in CONFIGURATION_KEYS:
         log.warn('"%s" is not a known configuration key', key)
+
+    if key in DEPRECATED.keys():
+        message = "{} is deprecated: {}".format(key, DEPRECATED[key])
+        log.warn(message)
+
     config_data[key] = ty(value)
 
 def recursive_remove(config_data, key):

--- a/binstar_client/utils/config.py
+++ b/binstar_client/utils/config.py
@@ -62,6 +62,7 @@ CONFIGURATION_KEYS = [
     'sites',
     'url',
     'verify_ssl',
+    'ssl_verify',
 ]
 SEARCH_PATH = (
     dirs.site_data_dir,
@@ -108,7 +109,7 @@ def get_server_api(token=None, site=None, log_level=logging.INFO, cls=None, **kw
     else:
         token = load_token(url)
 
-    verify = config.get('verify_ssl', True)
+    verify = config.get('ssl_verify', config.get('verify_ssl', True))
     return cls(token, domain=url, verify=verify, **kwargs)
 
 


### PR DESCRIPTION
Closes #420 as it implements `ssl_verify` as a config value. 
`verify_ssl` still works but with less precedence than `ssl_verify`