### PR TITLE
Removed --from-channel and --to-channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Using session to upload packages when the storage is in the same server as the API
 * Fixed file uploads with special characters
 * Fixed problems with pretty printing
+* Removed from-channel and to-channel options from copy command
 
 ## Version 1.6.5 (2017/09/08)
 

--- a/binstar_client/commands/copy.py
+++ b/binstar_client/commands/copy.py
@@ -16,8 +16,8 @@ def main(args):
     channels = aserver_api.list_channels(spec.user)
     label_text = 'label' if (args.from_label and args.to_label) else 'channel'
 
-    from_label = args.from_channel or args.from_label
-    to_label = args.to_channel or args.to_label
+    from_label = args.from_label
+    to_label = args.to_label
     if from_label not in channels:
         raise errors.UserError(
             "{} {} does not exist\n\tplease choose from: {}".format(
@@ -26,9 +26,11 @@ def main(args):
                 ', '.join(channels)
             ))
 
-    # TODO: add/replace from_channel => from_label and to_channel => to_label
-    files = aserver_api.copy(spec.user, spec.package, spec.version, spec._basename,
-                    to_owner=args.to_owner, from_channel=from_label, to_channel=to_label)
+    files = aserver_api.copy(
+        spec.user, spec.package, spec.version, spec._basename,
+        to_owner=args.to_owner, from_label=from_label, to_label=to_label
+    )
+
     for binstar_file in files:
         print("Copied file: %(basename)s" % binstar_file)
 
@@ -49,9 +51,6 @@ def add_parser(subparsers):
 
     _from = parser.add_mutually_exclusive_group()
     _to = parser.add_mutually_exclusive_group()
-
-    _from.add_argument('--from-channel', help='[DEPRECATED]Channel to copy packages from')
-    _to.add_argument('--to-channel', help='[DEPRECATED]Channel to put all packages into')
 
     _from.add_argument('--from-label', help='Label to copy packages from', default='main')
     _to.add_argument('--to-label', help='Label to put all packages into', default='main')

--- a/binstar_client/mixins/package.py
+++ b/binstar_client/mixins/package.py
@@ -8,12 +8,12 @@ from binstar_client.utils import jencode
 class PackageMixin(object):
 
     def copy(self, owner, package, version, basename=None,
-                     to_owner=None, from_channel='main', to_channel='main'):
+                     to_owner=None, from_label='main', to_label='main'):
         url = '%s/copy/package/%s/%s/%s' % (self.domain, owner, package, version)
         if basename:
             url += '/%s' % basename
 
-        payload = dict(to_owner=to_owner, from_channel=from_channel, to_channel=to_channel)
+        payload = dict(to_owner=to_owner, from_channel=from_label, to_channel=to_label)
         data, headers = jencode(payload)
         res = self.session.post(url, data=data, headers=headers)
         self._check_response(res)

--- a/binstar_client/tests/test_copy.py
+++ b/binstar_client/tests/test_copy.py
@@ -8,6 +8,7 @@ from binstar_client.scripts.cli import main
 from binstar_client.tests.fixture import CLITestCase
 from binstar_client.tests.urlmock import urlpatch
 
+
 class Test(CLITestCase):
     @urlpatch
     def test_copy_label(self, urls):
@@ -21,17 +22,6 @@ class Test(CLITestCase):
         self.assertEqual(req['from_channel'], 'dev')
         self.assertEqual(req['to_channel'], 'release/xyz')
 
-    @urlpatch
-    def test_copy_channel(self, urls):
-        urls.register(method='GET', path='/channels/u1', content='["dev"]')
-        copy = urls.register(method='POST', path='/copy/package/u1/p1/1.0', content='[{"basename": "copied-file_1.0.tgz"}]')
-
-        main(['--show-traceback', 'copy', '--from-channel', 'dev', '--to-channel', 'release/xyz', 'u1/p1/1.0'], False)
-
-        urls.assertAllCalled()
-        req = json.loads(copy.req.body)
-        self.assertEqual(req['from_channel'], 'dev')
-        self.assertEqual(req['to_channel'], 'release/xyz')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
These options were already deprecated and it was confusing the users.