### PR TITLE
Fix/forbid upload different pkg type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 * Deprecated verify_ssl in favor of ssl_verify
+* Validation to prevent uploading package with more than one type
 
 ### Fixed
 

--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -116,7 +116,7 @@ def get_version(args, release_attrs, package_type):
 
 def add_package(aserver_api, args, username, package_name, package_attrs, package_type):
     try:
-        aserver_api.package(username, package_name)
+        return aserver_api.package(username, package_name)
     except errors.NotFound:
         if not args.auto_register:
             message = (
@@ -139,7 +139,7 @@ def add_package(aserver_api, args, username, package_name, package_attrs, packag
 
             public = not args.private
 
-            aserver_api.add_package(
+            return aserver_api.add_package(
                 username,
                 package_name,
                 summary,
@@ -204,7 +204,15 @@ def upload_package(filename, package_type, aserver_api, username, args):
     package_name = get_package_name(args, package_attrs, filename, package_type)
     version = get_version(args, release_attrs, package_type)
 
-    add_package(aserver_api, args, username, package_name, package_attrs, package_type)
+    package = add_package(aserver_api, args, username, package_name, package_attrs, package_type)
+    if package_type not in package.get('package_types'):
+        message = 'You already have a {} named \'{}\'. Use a different name for this {}.'.format(
+            PACKAGE_TYPES[package.get('package_types')[0]].lower(),
+            package_name,
+            PACKAGE_TYPES[package_type].lower()
+        )
+        log.error(message)
+        raise errors.BinstarError(message)
     add_release(aserver_api, args, username, package_name, version, release_attrs)
     binstar_package_type = file_attrs.pop('binstar_package_type', package_type)
 

--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -205,9 +205,9 @@ def upload_package(filename, package_type, aserver_api, username, args):
     version = get_version(args, release_attrs, package_type)
 
     package = add_package(aserver_api, args, username, package_name, package_attrs, package_type)
-    if package_type not in package.get('package_types'):
+    if package_type not in package.get('package_types', []):
         message = 'You already have a {} named \'{}\'. Use a different name for this {}.'.format(
-            PACKAGE_TYPES[package.get('package_types')[0]].lower(),
+            PACKAGE_TYPES[package.get('package_types', ['conda'])[0]].lower(),
             package_name,
             PACKAGE_TYPES[package_type].lower()
         )

--- a/binstar_client/tests/test_upload.py
+++ b/binstar_client/tests/test_upload.py
@@ -21,7 +21,8 @@ class Test(CLITestCase):
         registry.register(method='HEAD', path='/', status=200)
         registry.register(method='GET', path='/user', content='{"login": "eggs"}')
         registry.register(method='GET', path='/package/eggs/foo', content='{}', status=404)
-        registry.register(method='POST', path='/package/eggs/foo', content='{}', status=200)
+        content = {"package_types": ['conda']}
+        registry.register(method='POST', path='/package/eggs/foo', content=content, status=200)
         registry.register(method='GET', path='/release/eggs/foo/0.1', content='{}')
         registry.register(method='GET', path='/dist/eggs/foo/0.1/osx-64/foo-0.1-0.tar.bz2', status=404, content='{}')
 
@@ -49,7 +50,8 @@ class Test(CLITestCase):
     def test_upload_conda(self, registry):
         registry.register(method='HEAD', path='/', status=200)
         registry.register(method='GET', path='/user', content='{"login": "eggs"}')
-        registry.register(method='GET', path='/package/eggs/foo', content='{}')
+        content = {'package_types': ['conda']}
+        registry.register(method='GET', path='/package/eggs/foo', content=content)
         registry.register(method='GET', path='/release/eggs/foo/0.1', content='{}')
         registry.register(method='GET', path='/dist/eggs/foo/0.1/osx-64/foo-0.1-0.tar.bz2', status=404, content='{}')
 
@@ -67,7 +69,8 @@ class Test(CLITestCase):
     def test_upload_pypi(self, registry):
         registry.register(method='HEAD', path='/', status=200)
         registry.register(method='GET', path='/user', content='{"login": "eggs"}')
-        registry.register(method='GET', path='/package/eggs/test-package34', content='{}')
+        content = {'package_types': 'pypi'}
+        registry.register(method='GET', path='/package/eggs/test-package34', content=content)
         registry.register(method='GET', path='/release/eggs/test-package34/0.3.1', content='{}')
         registry.register(method='GET', path='/dist/eggs/test-package34/0.3.1/test_package34-0.3.1.tar.gz', status=404, content='{}')
 
@@ -85,7 +88,8 @@ class Test(CLITestCase):
     def test_upload_file(self, registry):
         registry.register(method='HEAD', path='/', status=200)
         registry.register(method='GET', path='/user', content='{"login": "eggs"}')
-        registry.register(method='GET', path='/package/eggs/test-package34', content='{}')
+        content = {'package_types': ['file']}
+        registry.register(method='GET', path='/package/eggs/test-package34', content=content)
         registry.register(method='GET', path='/release/eggs/test-package34/0.3.1', content='{}')
         registry.register(method='GET', path='/dist/eggs/test-package34/0.3.1/test_package34-0.3.1.tar.gz', status=404, content='{}')
 
@@ -96,10 +100,10 @@ class Test(CLITestCase):
         registry.register(method='POST', path='/commit/eggs/test-package34/0.3.1/test_package34-0.3.1.tar.gz', status=200, content={})
 
         main(['--show-traceback', 'upload',
-              '--package-type', 'file',
-              '--package', 'test-package34',
-              '--version', '0.3.1',
-              data_dir('test_package34-0.3.1.tar.gz')], False)
+            '--package-type', 'file',
+            '--package', 'test-package34',
+            '--version', '0.3.1',
+            data_dir('test_package34-0.3.1.tar.gz')], False)
 
         registry.assertAllCalled()
 
@@ -187,7 +191,8 @@ class Test(CLITestCase):
         # regression test for #364
         registry.register(method='HEAD', path='/', status=200)
         registry.register(method='GET', path='/user', content='{"login": "eggs"}')
-        registry.register(method='GET', path='/package/eggs/foo', content='{}')
+        content = {'package_types': 'conda'}
+        registry.register(method='GET', path='/package/eggs/foo', content=content)
         registry.register(method='GET', path='/release/eggs/foo/0.1', content='{}')
         registry.register(method='GET', path='/dist/eggs/foo/0.1/osx-64/foo-0.1-0.tar.bz2', status=200, content='{}')
 
@@ -202,7 +207,8 @@ class Test(CLITestCase):
         registry.register(method='HEAD', path='/', status=200)
         registry.register(method='GET', path='/user', content='{"login": "eggs"}')
         registry.register(method='GET', path='/package/eggs/foo', content='{}', status=404)
-        registry.register(method='POST', path='/package/eggs/foo', content='{}', status=200)
+        content = {'package_types': ['conda']}
+        registry.register(method='POST', path='/package/eggs/foo', content=content, status=200)
         registry.register(method='GET', path='/release/eggs/foo/0.1', content='{}')
         registry.register(method='GET', path='/dist/eggs/foo/0.1/osx-64/foo-0.1-0.tar.bz2', status=404, content='{}')
 


### PR DESCRIPTION
Closes [#4632](https://github.com/Anaconda-Platform/anaconda-server/issues/4632)

It prevents uploading packages with different type and same name

Steps to reproduce:

1. Upload a conda package
2. Upload a notebook with the same name as the conda package
3. Verify that an error message appears