### PR TITLE
Remove ruamel_yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 * Fixed upload message when package_types is empty
+* Revert to using PyYAML instead of ruamel.yaml
 
 ## Version 1.6.8 (2018/01/24)
 

--- a/binstar_client/utils/yaml.py
+++ b/binstar_client/utils/yaml.py
@@ -1,23 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-try:
-    import ruamel_yaml as yaml
-except ImportError:                                         # pragma: no cover
-    try:                                                    # pragma: no cover
-        import ruamel.yaml as yaml                          # pragma: no cover
-    except ImportError:                                     # pragma: no cover
-        raise ImportError("No yaml library available.\n"    # pragma: no cover
-                            "To proceed, conda install "      # pragma: no cover
-                            "ruamel_yaml")                    # pragma: no cover
+from yaml import safe_dump, safe_load
+
 
 def yaml_load(stream):
     """Loads a dictionary from a stream"""
-    return yaml.load(stream, Loader=yaml.RoundTripLoader, version="1.2")
+    return safe_load(stream)
 
 
 def yaml_dump(data, stream=None):
     """Dumps an object to a YAML string"""
-    return yaml.dump(data, stream=stream, Dumper=yaml.RoundTripDumper,
-                     block_seq_indent=2, default_flow_style=False,
-                     indent=2)
+    return safe_dump(data, stream=stream, default_flow_style=False)

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - nbformat >=4.4.0
     - clyent >=1.2.0
     - requests >=2.9.1
-    - ruamel_yaml >=0.11.14
+    - PyYAML >=3.12
     - python-dateutil >=2.6.1
 
 about:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ six
 nbformat >=4.4.0
 clyent >=1.2.0
 requests >=2.9.1
-ruamel.yaml >=0.11.14
+PyYAML >=3.12
 python-dateutil >=2.6.1


### PR DESCRIPTION
The whole ruamel.yaml vs ruamel_yaml is causing some issues with anaconda-server development environment. We're going back to PyYAML for the time being.