### PR TITLE
Add support for read-only and lockdown headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG:
 
+## Next version
+
+## Added
+
+* Show warnings when lock down and read-only headers are present
+
 ## Version 1.6.9 (2018/01/31)
 
 ### Fixed


### PR DESCRIPTION
A warning will be displayed when a response from the server contains the read only or lockdown header.