### PR TITLE
Support unicode yaml tag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # CHANGELOG:
 
+## Next version
+
+### Fixed
+
+* Fixed loading of tagged config files under Python 3
+
 ## Version 1.6.10 (2018/02/19)
 
-## Added
+### Added
 
 * Added support for setting a default upload user
 * Show warnings when lock down and read-only headers are present

--- a/binstar_client/commands/config.py
+++ b/binstar_client/commands/config.py
@@ -68,10 +68,10 @@ from argparse import RawDescriptionHelpFormatter
 
 from six import text_type
 
-from binstar_client.errors import ShowHelp, UserError
+from binstar_client.errors import ShowHelp
 from binstar_client.utils.config import (SEARCH_PATH, USER_CONFIG, SYSTEM_CONFIG, CONFIGURATION_KEYS,
                                          get_config, save_config, load_config, load_file_configs)
-from ..utils.yaml import yaml_load, yaml_dump
+from ..utils.yaml import yaml_dump, safe_load
 
 logger = logging.getLogger('binstar.config')
 
@@ -80,7 +80,7 @@ DEPRECATED = {
 }
 
 
-def recursive_set(config_data, key, value, ty):
+def recursive_set(config_data, key, value, type_):
     while '.' in key:
         prefix, key = key.split('.', 1)
         config_data = config_data.setdefault(prefix, {})
@@ -92,7 +92,7 @@ def recursive_set(config_data, key, value, ty):
         message = "{} is deprecated: {}".format(key, DEPRECATED[key])
         logger.warning(message)
 
-    config_data[key] = ty(value)
+    config_data[key] = type_(value)
 
 
 def recursive_remove(config_data, key):
@@ -158,7 +158,7 @@ def add_parser(subparsers):
                                    epilog=__doc__,
                                    formatter_class=RawDescriptionHelpFormatter)
 
-    parser.add_argument('--type', default=text_type,
+    parser.add_argument('--type', default=safe_load,
                         help='The type of the values in the set commands')
 
     agroup = parser.add_argument_group('actions')

--- a/binstar_client/utils/test/test_config.py
+++ b/binstar_client/utils/test/test_config.py
@@ -49,3 +49,34 @@ sites:
                     }
                 }
             })
+
+    def test_support_tags(self):
+        tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmpdir)
+
+        user_dir = join(tmpdir, 'user')
+        os.mkdir(user_dir)
+
+        with open(join(user_dir, 'config.yaml'), 'wb') as fd:
+            fd.write(b'''
+!!python/unicode 'sites':
+   !!python/unicode 'alpha': {!!python/unicode 'url': !!python/unicode 'foobar'}
+   !!python/unicode 'binstar': {!!python/unicode 'url': !!python/unicode 'barfoo'}
+ssl_verify: False
+''')
+
+        with mock.patch('binstar_client.utils.config.SEARCH_PATH', [user_dir]), \
+                mock.patch('binstar_client.utils.config.DEFAULT_CONFIG', {}):
+            cfg = config.get_config()
+
+            self.assertEqual(cfg, {
+                'ssl_verify': False,
+                'sites': {
+                    'alpha': {
+                        'url': 'foobar',
+                    },
+                    'binstar': {
+                        'url': 'barfoo',
+                    },
+                }
+            })

--- a/binstar_client/utils/yaml.py
+++ b/binstar_client/utils/yaml.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from yaml import safe_dump, safe_load
+from yaml import dump, load, safe_load
 
 
 def yaml_load(stream):
     """Loads a dictionary from a stream"""
-    return safe_load(stream)
+    return load(stream)
 
 
 def yaml_dump(data, stream=None):
     """Dumps an object to a YAML string"""
-    return safe_dump(data, stream=stream, default_flow_style=False)
+    return dump(data, stream=stream, default_flow_style=False)

--- a/binstar_client/utils/yaml.py
+++ b/binstar_client/utils/yaml.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from yaml import dump, load, safe_load
+from yaml import safe_load, safe_dump, SafeLoader
+
+
+SafeLoader.add_constructor('tag:yaml.org,2002:python/unicode', SafeLoader.construct_yaml_str)
 
 
 def yaml_load(stream):
     """Loads a dictionary from a stream"""
-    return load(stream)
+    return safe_load(stream)
 
 
 def yaml_dump(data, stream=None):
     """Dumps an object to a YAML string"""
-    return dump(data, stream=stream, default_flow_style=False)
+    return safe_dump(data, stream=stream, default_flow_style=False)


### PR DESCRIPTION
Fixes #459. Adds support for a unicode tag (which shouldn't work in Py3).

https://github.com/ContinuumIO/anaconda-issues/issues/8605#issuecomment-366759140.

The client won't blow when it sees a unicode tag.