### PR TITLE
Inspect notebook metadata on upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ env:
   global:
     # Environment variables used by astropy helpers
     - CONDA_CHANNELS="https://conda.anaconda.org/t/$ANACONDA_ORG_TOKEN/binstar conda-kapsel"
-    - CONDA_DEPENDENCIES="pip setuptools=23.0.0  clyent pillow psutil nbformat anaconda-project coverage==3.7.1 mock "
+    - CONDA_DEPENDENCIES="pip setuptools=23.0.0 clyent pillow psutil nbformat anaconda-project mock"
+    - PIP_DEPENDENCIES="coverage==3.7.1 freezegun==0.3.9"
 
 matrix:
   include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG:
 
+## Next version
+
+## Fixed
+
+* Upload now reads Jupyter notebooks metadata
+
 ## Version 1.6.11 (2018/02/20)
 
 ### Fixed

--- a/binstar_client/inspect_package/ipynb.py
+++ b/binstar_client/inspect_package/ipynb.py
@@ -11,24 +11,27 @@ from ..utils.notebook.inflection import parameterize
 
 
 def _get_name(filename):
-    re.sub('\-ipynb$', '', parameterize(os.path.basename(filename)))
+    return re.sub('\-ipynb$', '', parameterize(os.path.basename(filename)))
 
 
 def inspect_ipynb_package(filename, fileobj, *args, **kwargs):
-    notebook = nbformat.read(fileobj)
+    notebook = nbformat.read(fileobj, nbformat.NO_CONVERT)
     summary = notebook['metadata'].get('summary', 'Jupyter Notebook')
+    description = notebook['metadata'].get('description', 'Jupyter Notebook')
 
     package_data = {
         'name': _get_name(filename),
-        'summary': summary
+        'summary': summary,
+        'description': description,
     }
 
-    if 'parser_args' in kwargs:
+    if 'parser_args' in kwargs and kwargs['parser_args'].thumbnail:
         package_data['thumbnail'] = data_uri_from(kwargs['parser_args'].thumbnail)
 
     release_data = {
         'version': time.strftime('%Y.%m.%d.%H%M'),
-        'description': summary
+        'summary': summary,
+        'description': description,
     }
 
     file_data = {

--- a/binstar_client/inspect_package/ipynb.py
+++ b/binstar_client/inspect_package/ipynb.py
@@ -4,14 +4,12 @@ import os
 import re
 import time
 
+from datetime import datetime
+
 import nbformat
 
 from ..utils.notebook.data_uri import data_uri_from
 from ..utils.notebook.inflection import parameterize
-
-
-def _get_name(filename):
-    return re.sub('\-ipynb$', '', parameterize(os.path.basename(filename)))
 
 
 def inspect_ipynb_package(filename, fileobj, *args, **kwargs):
@@ -20,7 +18,7 @@ def inspect_ipynb_package(filename, fileobj, *args, **kwargs):
     description = notebook['metadata'].get('description', 'Jupyter Notebook')
 
     package_data = {
-        'name': _get_name(filename),
+        'name': re.sub('\-ipynb$', '', parameterize(os.path.basename(filename))),
         'summary': summary,
         'description': description,
     }
@@ -29,7 +27,7 @@ def inspect_ipynb_package(filename, fileobj, *args, **kwargs):
         package_data['thumbnail'] = data_uri_from(kwargs['parser_args'].thumbnail)
 
     release_data = {
-        'version': time.strftime('%Y.%m.%d.%H%M'),
+        'version': datetime.now().strftime('%Y.%m.%d.%H%M'),
         'summary': summary,
         'description': description,
     }

--- a/binstar_client/inspect_package/ipynb.py
+++ b/binstar_client/inspect_package/ipynb.py
@@ -1,74 +1,38 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
+
 import os
 import re
 import time
-from ..utils.notebook.inflection import parameterize
+
+import nbformat
+
 from ..utils.notebook.data_uri import data_uri_from
+from ..utils.notebook.inflection import parameterize
 
 
-class IPythonNotebook(object):
-    _name = None
-    _version = None
-    thumbnail_file = None
-
-    def __init__(self, filename, fileobj, *args, **kwargs):
-
-        if isinstance(filename, bytes):
-            filename = filename.decode('utf-8', errors='ignore')
-
-        self.filename = filename
-        self.thumbnail_file = kwargs.get('thumbnail_file', None)
-
-    @property
-    def basename(self):
-        return os.path.basename(self.filename)
-
-    @property
-    def name(self):
-        if self._name is None:
-            return re.sub('\-ipynb$', '', parameterize(os.path.basename(self.filename)))
-        return self._name
-
-    @property
-    def version(self):
-        if self._version is None:
-            self._version = time.strftime('%Y.%m.%d.%H%M')
-        return self._version
-
-    @property
-    def thumbnail(self):
-        if self.thumbnail_file is None:
-            return None
-        return data_uri_from(self.thumbnail_file)
-
-    def get_package_data(self):
-        if self.thumbnail_file is None:
-            return {
-                'name': self.name,
-                'summary': 'IPython notebook'
-            }
-        else:
-            return {
-                'name': self.name,
-                'summary': 'IPython notebook',
-                'thumbnail': self.thumbnail
-            }
+def _get_name(filename):
+    re.sub('\-ipynb$', '', parameterize(os.path.basename(filename)))
 
 
 def inspect_ipynb_package(filename, fileobj, *args, **kwargs):
-    if 'parser_args' in kwargs:
-        thumbnail_file = kwargs['parser_args'].thumbnail
-        ipython_notebook = IPythonNotebook(filename, fileobj, thumbnail_file=thumbnail_file)
-    else:
-        ipython_notebook = IPythonNotebook(filename, fileobj)
+    notebook = nbformat.read(fileobj)
+    summary = notebook['metadata'].get('summary', 'Jupyter Notebook')
 
-    package_data = ipython_notebook.get_package_data()
-    release_data = {
-        'version': ipython_notebook.version,
-        'description': ''
+    package_data = {
+        'name': _get_name(filename),
+        'summary': summary
     }
+
+    if 'parser_args' in kwargs:
+        package_data['thumbnail'] = data_uri_from(kwargs['parser_args'].thumbnail)
+
+    release_data = {
+        'version': time.strftime('%Y.%m.%d.%H%M'),
+        'description': summary
+    }
+
     file_data = {
-        'basename': ipython_notebook.basename,
+        'basename': os.path.basename(filename),
         'attrs': {}
     }
 

--- a/binstar_client/inspect_package/tests/data/notebook-no-metadata.ipynb
+++ b/binstar_client/inspect_package/tests/data/notebook-no-metadata.ipynb
@@ -29,10 +29,7 @@
    "source": []
   }
  ],
- "metadata": {
-     "summary": "ipynb summary",
-     "description": "ipynb description"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/binstar_client/inspect_package/tests/test_ipynb.py
+++ b/binstar_client/inspect_package/tests/test_ipynb.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 
 import unittest
 

--- a/binstar_client/inspect_package/tests/test_ipynb.py
+++ b/binstar_client/inspect_package/tests/test_ipynb.py
@@ -1,42 +1,76 @@
 
 import unittest
-import io
 
-from binstar_client.inspect_package.ipynb import IPythonNotebook, inspect_ipynb_package
+from collections import namedtuple
+
+from freezegun import freeze_time
+
+from binstar_client.inspect_package.ipynb import inspect_ipynb_package
 from binstar_client.utils.test.utils import data_dir
 
 
-class IPythonNotebookTestCase(unittest.TestCase):
-    def test_package_name(self):
-
-        fileobj = io.StringIO()
-        self.assertEqual(IPythonNotebook('notebook.ipynb', fileobj).name, 'notebook')
-
-    def test_package_name_unicode(self):
-
-        fileobj = io.StringIO()
-        self.assertEqual(IPythonNotebook(b'na\xcc\x83o.ipynb', fileobj).name, 'nao')
-
-    def test_version(self):
-        with open(data_dir('notebook.ipynb')) as fileobj:
-            self.assertIsInstance(IPythonNotebook('notebook.ipynb', fileobj).version, str)
-
-
 class InspectIPYNBPackageTest(unittest.TestCase):
-    def test_inspect_ipynb_package(self):
-        with open(data_dir('notebook.ipynb')) as fileobj:
-            package_data, release_data, file_data = inspect_ipynb_package('notebook.ipynb', fileobj)
+    def test_package_data(self):
+        with open(data_dir('notebook.ipynb')) as fd:
+            package_data, _, _ = inspect_ipynb_package('notebook.ipynb', fd)
 
         self.assertEqual({
             'name': 'notebook',
-            'summary': 'IPython notebook'
+            'description': 'ipynb description',
+            'summary': 'ipynb summary',
         }, package_data)
+
+    def test_package_data_no_metadata(self):
+        with open(data_dir('notebook-no-metadata.ipynb')) as fd:
+            package_data, _, _ = inspect_ipynb_package('notebook.ipynb', fd)
+
+        self.assertEqual({
+            'name': 'notebook',
+            'description': 'Jupyter Notebook',
+            'summary': 'Jupyter Notebook',
+        }, package_data)
+
+    def test_package_data_normalized_name(self):
+        with open(data_dir('notebook.ipynb')) as fd:
+            package_data, _, _ = inspect_ipynb_package('test nótëbOOk.ipynb', fd)
+
+        self.assertIn('name', package_data)
+        self.assertEqual(package_data['name'], 'test-notebook')
+
+    def test_package_thumbnail(self):
+        parser_args = namedtuple('parser_args', ['thumbnail'])(data_dir('43c9b994a4d96f779dad87219d645c9f.png'))
+        with open(data_dir('notebook.ipynb')) as fd:
+            package_data, _, _ = inspect_ipynb_package('notebook.ipynb', fd, parser_args=parser_args)
+
+        self.assertIn('thumbnail', package_data)
+
+    def test_release_data(self):
+        with freeze_time('2018-02-01 09:10:00', tz_offset=0):
+            with open(data_dir('notebook.ipynb')) as fd:
+                _, release_data, _ = inspect_ipynb_package('notebook.ipynb', fd)
+
+        self.assertEqual({
+            'version': '2018.02.01.0910',
+            'description': 'ipynb description',
+            'summary': 'ipynb summary',
+        }, release_data)
+
+    def test_release_data_no_metadata(self):
+        with freeze_time('2018-05-03 12:30:00', tz_offset=0):
+            with open(data_dir('notebook-no-metadata.ipynb')) as fd:
+                _, release_data, _ = inspect_ipynb_package('notebook-no-metadata.ipynb', fd)
+
+        self.assertEqual({
+            'version': '2018.05.03.1230',
+            'description': 'Jupyter Notebook',
+            'summary': 'Jupyter Notebook',
+        }, release_data)
+
+    def test_file_data(self):
+        with open(data_dir('notebook.ipynb')) as fd:
+            _, _, file_data = inspect_ipynb_package('notebook.ipynb', fd)
 
         self.assertEqual({
             'basename': 'notebook.ipynb',
             'attrs': {}
         }, file_data)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/binstar_client/inspect_package/tests/test_ipynb.py
+++ b/binstar_client/inspect_package/tests/test_ipynb.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import unicode_literals
 
 import unittest

--- a/binstar_client/tests/test_upload.py
+++ b/binstar_client/tests/test_upload.py
@@ -1,11 +1,8 @@
-'''
-Created on Feb 18, 2014
-
-@author: sean
-'''
 from __future__ import unicode_literals
 
 import unittest
+
+from freezegun import freeze_time
 from mock import patch
 
 from binstar_client import errors

--- a/binstar_client/tests/test_upload.py
+++ b/binstar_client/tests/test_upload.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import unittest
 
-from freezegun import freeze_time
 from mock import patch
 
 from binstar_client import errors

--- a/binstar_client/utils/notebook/__init__.py
+++ b/binstar_client/utils/notebook/__init__.py
@@ -1,7 +1,4 @@
-try:
-    import nbformat
-except ImportError:
-    nbformat = None
+import nbformat
 
 from six.moves.urllib.parse import urlparse
 

--- a/circle.yml
+++ b/circle.yml
@@ -6,12 +6,12 @@ machine:
     PYTHON_TEST: "$HOME/miniconda/envs/test/bin/python"
     PATH: "$HOME/miniconda/bin:$PATH"  # To avoid prepending this to the commands on circle-ci
     # Python versions to test (Maximum of 2 different versions for now)
-    PY_VERSIONS: "2.7 3.4 3.5"
+    PY_VERSIONS: "2.7 3.4 3.5 3.6"
     # Used by astropy-ci helpers
     TRAVIS_OS_NAME: "linux"
     CONDA_CHANNELS: "https://conda.anaconda.org/t/$ANACONDA_ORG_TOKEN/binstar conda-kapsel"
     CONDA_DEPENDENCIES: "pip setuptools=23.0.0 clyent pillow psutil nbformat anaconda-project mock"
-    PIP_DEPENDENCIES: "coverage==3.7.1"
+    PIP_DEPENDENCIES: "coverage==3.7.1 freezegun==0.3.9"
 
 dependencies:
   override:

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# Install nose, nose-progressive, and watchdog
+# Install nose, freezegun, nose-progressive, and watchdog
 watchmedo shell-command -R -p "*.py" \
   -c "nosetests --with-progressive"


### PR DESCRIPTION
Closes https://github.com/Anaconda-Platform/anaconda-server/issues/4783.

This will read the metadata of the notebook during upload allowing updates to the summary on repo.