### PR TITLE
Add back get_binstar function

### DIFF
--- a/binstar_client/utils/__init__.py
+++ b/binstar_client/utils/__init__.py
@@ -16,6 +16,7 @@ from .spec import PackageSpec, package_specs, parse_specs
 # Re-export config
 from .config import (get_server_api, dirs, load_token, store_token,
                      remove_token, get_config, set_config, load_config,
+                     get_binstar,
                      USER_CONFIG, USER_LOGDIR, SITE_CONFIG, DEFAULT_CONFIG)
 
 from six.moves import input

--- a/binstar_client/utils/__init__.py
+++ b/binstar_client/utils/__init__.py
@@ -14,7 +14,8 @@ from pkg_resources import parse_version as pv
 from .spec import PackageSpec, package_specs, parse_specs
 
 # Re-export config
-from .config import (get_server_api, dirs, load_token, store_token, remove_token, get_config, set_config, load_config,
+from .config import (get_server_api, dirs, load_token, store_token,
+                     remove_token, get_config, set_config, load_config,
                      USER_CONFIG, USER_LOGDIR, SITE_CONFIG, DEFAULT_CONFIG)
 
 from six.moves import input

--- a/binstar_client/utils/config.py
+++ b/binstar_client/utils/config.py
@@ -120,6 +120,26 @@ def get_server_api(token=None, site=None, cls=None, config=None, **kwargs):
     return cls(token, domain=url, verify=verify, **kwargs)
 
 
+def get_binstar(args=None, cls=None):
+    """
+    DEPRECATED METHOD,
+
+    use `get_server_api`
+    """
+
+    warnings.warn(
+        'method get_binstar is deprecated, please use `get_server_api`',
+        DeprecationWarning
+    )
+
+    token = getattr(args, 'token', None)
+    log_level = getattr(args, 'log_level', logging.INFO)
+    site = getattr(args, 'site', None)
+
+    aserver_api = get_server_api(token, site, log_level, cls)
+    return aserver_api
+
+
 TOKEN_DIRS = [
     dirs.user_data_dir,
     join(dirname(USER_CONFIG), 'tokens'),


### PR DESCRIPTION
Fixes https://github.com/Anaconda-Platform/anaconda-client/issues/463

Even though this is deprecated, seems it is still needed in a few places. So go ahead and added it back.

cc @abarto