### PR TITLE
Only avoid logging KeyboardInterrupt's

### DIFF
--- a/binstar_client/scripts/cli.py
+++ b/binstar_client/scripts/cli.py
@@ -45,7 +45,7 @@ def file_or_token(value):
 
 def _custom_excepthook(logger, show_traceback=False):
     def excepthook(exc_type, exc_value, exc_traceback):
-        if issubclass(exc_type, KeyboardInterrupt) or not issubclass(exc_type, errors.ServerError):
+        if issubclass(exc_type, KeyboardInterrupt):
             return
 
         if show_traceback:


### PR DESCRIPTION
I've had some trouble lately with silent `anaconda-client` errors, so I started looking through the code to find the cause. I found that the issue was that the `excepthook` function returns without logging for all errors besides `ServerError`'s. It seems possible to me that the intent here may have actually been to return without logging for only `KeyboardInterrupt` and `ServerError`, in which case let me know and I can just take out the `not`, but personally I don't see any reason to hide `ServerError`'s from the user.

I'm proposing the following change based on my assumption that the desired behavior is to display the error message and error code to the user. If the desired behavior here is different than I assume, please let me know and I'd be happy to make whatever changes you suggest (including if there are any exception messages that may need to be more user friendly).

Before
```
anaconda-client:master$ python binstar_client/scripts/cli.py -t asdf upload -u myusername /path-to-build-output/build_output.tar.bz2
...
Uploading file "/path-to-build-outupt/osx-64/build_output.tar.bz2"
[WARNING] Distribution "osx-64/build_output.tar.bz2" already exists. Removing.
```
After (note the [ERROR] at the end)
```
anaconda-client:master$ python binstar_client/scripts/cli.py -t asdf upload -u myusername /path-to-build-output/build_output.tar.bz2
...
Uploading file "/path-to-build-outupt/osx-64/build_output.tar.bz2"
[WARNING] Distribution "osx-64/build_output.tar.bz2" already exists. Removing.
[ERROR] ('Authorization token is no longer valid', 401)
```

Related Issues
- https://github.com/Anaconda-Platform/anaconda-client/issues/501
- https://github.com/Anaconda-Platform/anaconda-client/issues/492
- https://github.com/Anaconda-Platform/anaconda-client/issues/418