### PR TITLE
Don't hide all uncaught exceptions

### DIFF
--- a/binstar_client/scripts/cli.py
+++ b/binstar_client/scripts/cli.py
@@ -45,7 +45,7 @@ def file_or_token(value):
 
 def _custom_excepthook(logger, show_traceback=False):
     def excepthook(exc_type, exc_value, exc_traceback):
-        if issubclass(exc_type, KeyboardInterrupt) or not issubclass(exc_type, errors.ServerError):
+        if issubclass(exc_type, KeyboardInterrupt):
             return
 
         if show_traceback:


### PR DESCRIPTION
I realized after I fixed this that it could be superseded by #507, but at least this one-line fix is so small it is easy to test and merge.  