### PR TITLE
Print informative error messages if upload fails.

### DIFF
--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -244,6 +244,9 @@ def upload_package(filename, package_type, aserver_api, username, args):
                 raise
             else:
                 logger.info('Distribution already exists. Skipping upload.\n')
+        except Exception as e:
+            logger.info('Uncaught exception: %s' % (str(e),))
+            raise
 
         if upload_info:
             logger.info("Upload complete\n")


### PR DESCRIPTION
It wastes me more than 3 hours to figure out the real reason why the upload fails. Hope this pull-request
can avoid wasting other's time.

The code is from https://github.com/Anaconda-Platform/anaconda-client/issues/501#issuecomment-470742898

It's also used by https://github.com/pytorch/audio/pull/354#issuecomment-573909753


- Closes #501
- Closes #516
- Closes #536