### PR TITLE
PR: Fix #555 - Upload - Fix of deprecated base64 functions usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next version
 
+### Fixed
+
+* Usage of deprecated base64 functions
+
 ## Version 1.7.2 (2018/08/29)
 
 ### Fixed


### PR DESCRIPTION
Introduction of a unified interface for `base64.encodestring`/`base64.encodebytes` for both python 2.7 and python 3+.

Fixes #555