### PR TITLE
AC-116: better support for standard r packages

### DIFF
--- a/binstar_client/__init__.py
+++ b/binstar_client/__init__.py
@@ -326,15 +326,19 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
         self._check_response(res)
         return res.json()
 
-    def add_package(self, login, package_name,
-                    summary=None,
-                    license=None,
-                    public=True,
-                    license_url=None,
-                    license_family=None,
-                    attrs=None,
-                    package_type=None):
-        '''
+    def add_package(
+            self,
+            login,
+            package_name,
+            summary=None,
+            license=None,
+            public=True,
+            license_url=None,
+            license_family=None,
+            attrs=None,
+            package_type=None,
+    ):
+        """
         Add a new package to a users account
 
         :param login: the login of the package owner
@@ -345,12 +349,15 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
         :param license_url: the url of the package license
         :param public: if true then the package will be hosted publicly
         :param attrs: A dictionary of extra attributes for this package
-        '''
+        """
+        if package_type is not None:
+            package_type = package_type.value
+
         url = '%s/package/%s/%s' % (self.domain, login, package_name)
 
         attrs = attrs or {}
         attrs['summary'] = summary
-        attrs['package_types'] = [package_type.value]
+        attrs['package_types'] = [package_type]
         attrs['license'] = {
             'name': license,
             'url': license_url,
@@ -482,7 +489,6 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
         self._check_response(res)
         return res.json()
 
-
     def download(self, login, package_name, release, basename, md5=None):
         '''
         Download a package distribution
@@ -522,7 +528,7 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
 
     def upload(self, login, package_name, release, basename, fd, distribution_type,
                description='', md5=None, size=None, dependencies=None, attrs=None, channels=('main',), callback=None):
-        '''
+        """
         Upload a new distribution to a package release.
 
         :param login: the login of the package owner
@@ -533,16 +539,20 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
         :param distribution_type: pypi or conda or ipynb, etc
         :param description: (optional) a short description about the file
         :param attrs: any extra attributes about the file (eg. build=1, pyversion='2.7', os='osx')
-
-        '''
+        """
         url = '%s/stage/%s/%s/%s/%s' % (self.domain, login, package_name, release, quote(basename))
         if attrs is None:
             attrs = {}
         if not isinstance(attrs, dict):
             raise TypeError('argument attrs must be a dictionary')
 
-        payload = dict(distribution_type=distribution_type.value, description=description, attrs=attrs,
-                       dependencies=dependencies, channels=channels)
+        payload = dict(
+            distribution_type=distribution_type.value,
+            description=description,
+            attrs=attrs,
+            dependencies=dependencies,
+            channels=channels,
+        )
 
         data, headers = jencode(payload)
         res = self.session.post(url, data=data, headers=headers)
@@ -588,10 +598,13 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
         return res.json()
 
     def search(self, query, package_type=None, platform=None):
+        if package_type is not None:
+            package_type = package_type.value
+
         url = '%s/search' % self.domain
         res = self.session.get(url, params={
             'name': query,
-            'type': package_type.value,
+            'type': package_type,
             'platform': platform,
         })
         self._check_response(res)

--- a/binstar_client/commands/download.py
+++ b/binstar_client/commands/download.py
@@ -47,8 +47,7 @@ def add_parser(subparsers):
     pkg_types = ', '.join(pkg_type.value for pkg_type in PackageType)
     parser.add_argument(
         '-t', '--package-type',
-        help='Set the package type [{0}]. Defaults to downloading all '
-             'package types available'.format(pkg_types),
+        help='Set the package type [{0}]. Defaults to downloading all package types available'.format(pkg_types),
         action='append',
     )
     parser.set_defaults(main=main)

--- a/binstar_client/commands/remove.py
+++ b/binstar_client/commands/remove.py
@@ -52,13 +52,28 @@ def main(args):
 
 def add_parser(subparsers):
 
-    parser = subparsers.add_parser('remove',
-                                      help='Remove an object from your Anaconda repository. Must refer to the formal package name as it appears in the URL of the package. Also use anaconda show <USERNAME> to see list of package names. Example: anaconda remove continuumio/empty-example-notebook',
-                                      description=__doc__, formatter_class=RawTextHelpFormatter)
+    parser = subparsers.add_parser(
+        'remove',
+        help=(
+            'Remove an object from your Anaconda repository. '
+            'Must refer to the formal package name as it appears in the URL of the package. '
+            'Also use anaconda show <USERNAME> to see list of package names. '
+            'Example: anaconda remove continuumio/empty-example-notebook'
+        ),
+        description=__doc__,
+        formatter_class=RawTextHelpFormatter,
+    )
 
-    parser.add_argument('specs', help='Package written as <user>[/<package>[/<version>[/<filename>]]]', type=parse_specs, nargs='+')
-    parser.add_argument('-f', '--force', help='Do not prompt removal', action='store_true')
-
-
+    parser.add_argument(
+        'specs',
+        help='Package written as <user>[/<package>[/<version>[/<filename>]]]',
+        type=parse_specs,
+        nargs='+',
+    )
+    parser.add_argument(
+        '-f', '--force',
+        help='Do not prompt removal',
+        action='store_true',
+    )
 
     parser.set_defaults(main=main)

--- a/binstar_client/commands/search.py
+++ b/binstar_client/commands/search.py
@@ -1,8 +1,10 @@
 """
 Search your Anaconda repository for packages.
 """
+
 import logging
 
+from binstar_client.utils import config
 from binstar_client.utils import get_server_api
 from binstar_client.utils.pprint import pprint_packages
 
@@ -10,10 +12,13 @@ logger = logging.getLogger('binstar.search')
 
 
 def search(args):
-
     aserver_api = get_server_api(args.token, args.site)
 
-    packages = aserver_api.search(args.name, package_type=args.package_type, platform=args.platform)
+    package_type = None
+    if args.package_type:
+        package_type = config.PackageType(args.package_type)
+
+    packages = aserver_api.search(args.name, package_type=package_type, platform=args.platform)
     pprint_packages(packages, access=False)
     logger.info("Found %i packages" % len(packages))
     logger.info("\nRun 'anaconda show <USER/PACKAGE>' to get installation details")
@@ -26,16 +31,22 @@ def add_parser(subparsers):
         description='Search in your Anaconda repository',
         epilog=__doc__
     )
-    parser.add_argument('name', nargs=1, help='Search string')
     parser.add_argument(
-        '-t', '--package-type', choices=['conda', 'pypi'],
-
+        'name',
+        nargs=1,
+        help='Search string',
+    )
+    parser.add_argument(
+        '-t', '--package-type',
+        # choices=['conda', 'pypi', 'r'],
         help='only search for packages of this type'
     )
     parser.add_argument(
         '-p', '--platform',
-        choices=['osx-32', 'osx-64', 'win-32', 'win-64', 'linux-32', 'linux-64',
-                 'linux-armv6l', 'linux-armv7l', 'linux-ppc64le', 'noarch'],
+        choices=[
+            'osx-32', 'osx-64', 'win-32', 'win-64', 'linux-32', 'linux-64', 'linux-aarch64', 'linux-armv6l',
+            'linux-armv7l', 'linux-ppc64le', 'linux-s390x', 'noarch',
+        ],
         help='only search for packages of the chosen platform'
     )
     parser.set_defaults(main=search)

--- a/binstar_client/commands/show.py
+++ b/binstar_client/commands/show.py
@@ -15,8 +15,7 @@ from argparse import RawTextHelpFormatter
 
 from binstar_client.utils import get_server_api, parse_specs
 from binstar_client.utils.config import PackageType
-from binstar_client.utils.pprint import pprint_user, pprint_packages, \
-    pprint_orgs
+from binstar_client.utils.pprint import format_package_type, pprint_user, pprint_packages, pprint_orgs
 
 logger = logging.getLogger('binstar.show')
 
@@ -67,10 +66,13 @@ def main(args):
     elif args.spec._package:
         package = aserver_api.package(spec.user, spec.package)
         package['access'] = 'public' if package['public'] else 'private'
+
+        package_types = ', '.join(format_package_type(item) for item in (package.get('package_types', None) or ()))
+
         logger.info('Name:    %(name)s' % package)
         logger.info('Summary: %(summary)s' % package)
         logger.info('Access:  %(access)s' % package)
-        logger.info('Package Types:  %s' % ', '.join(package.get('package_types')))
+        logger.info('Package Types:  %s' % package_types)
         logger.info('Versions:' % package)
         for release in package['releases']:
             logger.info('   + %(version)s' % release)

--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -342,10 +342,12 @@ def windows_glob(item):
 
 def add_parser(subparsers):
     description = 'Upload packages to your Anaconda repository'
-    parser = subparsers.add_parser('upload',
-                                   formatter_class=argparse.RawDescriptionHelpFormatter,
-                                   help=description, description=description,
-                                   epilog=__doc__)
+    parser = subparsers.add_parser(
+        'upload',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        help=description, description=description,
+        epilog=__doc__,
+    )
 
     parser.add_argument('files', nargs='+', help='Distributions to upload', default=[], type=windows_glob)
 
@@ -354,39 +356,109 @@ def add_parser(subparsers):
         'Warning: if the file {label}s do not include "main", '
         'the file will not show up in your user {label}')
 
-    parser.add_argument('-c', '--channel', action='append', default=[], dest='labels',
-                        help=label_help.format(deprecation='[DEPRECATED]\n', label='channel'),
-                        metavar='CHANNELS')
-    parser.add_argument('-l', '--label', action='append', dest='labels',
-                        help=label_help.format(deprecation='', label='label'))
-    parser.add_argument('--no-progress', help="Don't show upload progress", action='store_true')
-    parser.add_argument('-u', '--user', help='User account or Organization, defaults to the current user')
+    parser.add_argument(
+        '-c', '--channel',
+        action='append',
+        default=[],
+        dest='labels',
+        help=label_help.format(deprecation='[DEPRECATED]\n', label='channel'),
+        metavar='CHANNELS',
+    )
+    parser.add_argument(
+        '-l', '--label',
+        action='append',
+        dest='labels',
+        help=label_help.format(deprecation='', label='label'),
+    )
+    parser.add_argument(
+        '--no-progress',
+        help="Don't show upload progress",
+        action='store_true',
+    )
+    parser.add_argument(
+        '-u', '--user',
+        help='User account or Organization, defaults to the current user',
+    )
 
     mgroup = parser.add_argument_group('metadata options')
-    mgroup.add_argument('-p', '--package', help='Defaults to the package name in the uploaded file')
-    mgroup.add_argument('-v', '--version', help='Defaults to the package version in the uploaded file')
-    mgroup.add_argument('-s', '--summary', help='Set the summary of the package')
-    mgroup.add_argument('-t', '--package-type', help='Set the package type. Defaults to autodetect')
-    mgroup.add_argument('-d', '--description', help='description of the file(s)')
-    mgroup.add_argument('--thumbnail', help='Notebook\'s thumbnail image')
-    mgroup.add_argument('--private', help="Create the package with private access", action='store_true')
+    mgroup.add_argument(
+        '-p', '--package',
+        help='Defaults to the package name in the uploaded file',
+    )
+    mgroup.add_argument(
+        '-v', '--version',
+        help='Defaults to the package version in the uploaded file',
+    )
+    mgroup.add_argument(
+        '-s', '--summary',
+        help='Set the summary of the package',
+    )
+    mgroup.add_argument(
+        '-t', '--package-type',
+        help='Set the package type. Defaults to autodetect',
+    )
+    mgroup.add_argument(
+        '-d', '--description',
+        help='description of the file(s)',
+    )
+    mgroup.add_argument(
+        '--thumbnail',
+        help="Notebook's thumbnail image",
+    )
+    mgroup.add_argument(
+        '--private',
+        help='Create the package with private access',
+        action='store_true',
+    )
 
     register_group = parser.add_mutually_exclusive_group()
-    register_group.add_argument("--no-register", dest="auto_register", action="store_false",
-                        help='Don\'t create a new package namespace if it does not exist')
-    register_group.add_argument("--register", dest="auto_register", action="store_true",
-                        help='Create a new package namespace if it does not exist')
+    register_group.add_argument(
+        '--no-register',
+        dest='auto_register',
+        action='store_false',
+        help="Don't create a new package namespace if it does not exist",
+    )
+    register_group.add_argument(
+        '--register',
+        dest='auto_register',
+        action='store_true',
+        help='Create a new package namespace if it does not exist',
+    )
+
     parser.set_defaults(auto_register=DEFAULT_CONFIG.get('auto_register', True))
-    parser.add_argument('--build-id', help='Anaconda repository Build ID (internal only)')
+    parser.add_argument(
+        '--build-id',
+        help='Anaconda repository Build ID (internal only)',
+    )
 
     group = parser.add_mutually_exclusive_group()
-    group.add_argument('-i', '--interactive', action='store_const', help='Run an interactive prompt if any packages are missing',
-                        dest='mode', const='interactive')
-    group.add_argument('-f', '--fail', help='Fail if a package or release does not exist (default)',
-                                        action='store_const', dest='mode', const='fail')
-    group.add_argument('--force', help='Force a package upload regardless of errors',
-                                        action='store_const', dest='mode', const='force')
-    group.add_argument('--skip-existing', help='Skip errors on package batch upload if it already exists',
-                                        action='store_const', dest='mode', const='skip')
+    group.add_argument(
+        '-i', '--interactive',
+        action='store_const',
+        help='Run an interactive prompt if any packages are missing',
+        dest='mode',
+        const='interactive',
+    )
+    group.add_argument(
+        '-f', '--fail',
+        help='Fail if a package or release does not exist (default)',
+        action='store_const',
+        dest='mode',
+        const='fail',
+    )
+    group.add_argument(
+        '--force',
+        help='Force a package upload regardless of errors',
+        action='store_const',
+        dest='mode',
+        const='force',
+    )
+    group.add_argument(
+        '--skip-existing',
+        help='Skip errors on package batch upload if it already exists',
+        action='store_const',
+        dest='mode',
+        const='skip',
+    )
 
     parser.set_defaults(main=main)

--- a/binstar_client/utils/appdirs.py
+++ b/binstar_client/utils/appdirs.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2005-2010 ActiveState Software Inc.
 
 """Utilities for determining application-specific dirs.
@@ -23,9 +24,9 @@ PY3 = sys.version_info[0] == 3
 if PY3:
     unicode = str
 
+
 class AppDirsError(Exception):
     pass
-
 
 
 def user_data_dir(appname, appauthor=None, version=None, roaming=False):
@@ -66,13 +67,9 @@ def user_data_dir(appname, appauthor=None, version=None, roaming=False):
         const = roaming and "CSIDL_APPDATA" or "CSIDL_LOCAL_APPDATA"
         path = os.path.join(_get_win_folder(const), appauthor, appname)
     elif sys.platform == 'darwin':
-        path = os.path.join(
-            os.path.expanduser('~/Library/Application Support/'),
-            appname)
+        path = os.path.join(os.path.expanduser('~/Library/Application Support/'), appname)
     else:
-        path = os.path.join(
-            os.getenv('XDG_CONFIG_HOME', os.path.expanduser("~/.config")),
-            appname.lower())
+        path = os.path.join(os.getenv('XDG_CONFIG_HOME', os.path.expanduser("~/.config")), appname.lower())
     if version:
         path = os.path.join(path, version)
     return path
@@ -104,15 +101,11 @@ def site_data_dir(appname, appauthor=None, version=None):
     if sys.platform.startswith("win"):
         if appauthor is None:
             raise AppDirsError("must specify 'appauthor' on Windows")
-        path = os.path.join(_get_win_folder("CSIDL_COMMON_APPDATA"),
-                            appauthor, appname)
+        path = os.path.join(_get_win_folder("CSIDL_COMMON_APPDATA"), appauthor, appname)
     elif sys.platform == 'darwin':
-        path = os.path.join(
-            os.path.expanduser('/Library/Application Support'),
-            appname)
+        path = os.path.join(os.path.expanduser('/Library/Application Support'), appname)
     else:
-        # XDG default for $XDG_CONFIG_DIRS[0]. Perhaps should actually
-        # *use* that envvar, if defined.
+        # XDG default for $XDG_CONFIG_DIRS[0]. Perhaps should actually *use* that envvar, if defined.
         path = "/etc/xdg/" + appname.lower()
     if version:
         path = os.path.join(path, version)
@@ -152,21 +145,17 @@ def user_cache_dir(appname, appauthor=None, version=None, opinion=True):
     if sys.platform.startswith("win"):
         if appauthor is None:
             raise AppDirsError("must specify 'appauthor' on Windows")
-        path = os.path.join(_get_win_folder("CSIDL_LOCAL_APPDATA"),
-                            appauthor, appname)
+        path = os.path.join(_get_win_folder("CSIDL_LOCAL_APPDATA"), appauthor, appname)
         if opinion:
             path = os.path.join(path, "Cache")
     elif sys.platform == 'darwin':
-        path = os.path.join(
-            os.path.expanduser('~/Library/Caches'),
-            appname)
+        path = os.path.join(os.path.expanduser('~/Library/Caches'), appname)
     else:
-        path = os.path.join(
-            os.getenv('XDG_CACHE_HOME', os.path.expanduser('~/.cache')),
-            appname.lower())
+        path = os.path.join(os.getenv('XDG_CACHE_HOME', os.path.expanduser('~/.cache')), appname.lower())
     if version:
         path = os.path.join(path, version)
     return path
+
 
 def user_log_dir(appname, appauthor=None, version=None, opinion=True):
     r"""Return full path to the user-specific log dir for this application.
@@ -198,32 +187,37 @@ def user_log_dir(appname, appauthor=None, version=None, opinion=True):
     This can be disabled with the `opinion=False` option.
     """
     if sys.platform == "darwin":
-        path = os.path.join(
-            os.path.expanduser('~/Library/Logs'),
-            appname)
+        path = os.path.join(os.path.expanduser('~/Library/Logs'), appname)
     elif sys.platform == "win32":
-        path = user_data_dir(appname, appauthor, version); version = False
+        path = user_data_dir(appname, appauthor, version)
+        version = False
         if opinion:
             path = os.path.join(path, "Logs")
     else:
-        path = user_cache_dir(appname, appauthor, version); version = False
+        path = user_cache_dir(appname, appauthor, version)
+        version = False
         if opinion:
             path = os.path.join(path, "log")
     if version:
         path = os.path.join(path, version)
     return path
 
+
 class EnvAppDirs(object):
+
     def __init__(self, appname, appauthor, root_path):
         self.appname = appname
         self.appauthor = appauthor
         self.root_path = root_path
+
     @property
     def user_data_dir(self):
         return os.path.join(self.root_path, 'data')
+
     @property
     def site_data_dir(self):
         return os.path.join(self.root_path, 'data')
+
     @property
     def user_cache_dir(self):
         return os.path.join(self.root_path, 'cache')
@@ -235,37 +229,36 @@ class EnvAppDirs(object):
 
 class AppDirs(object):
     """Convenience wrapper for getting application dirs."""
+
     def __init__(self, appname, appauthor, version=None, roaming=False):
         self.appname = appname
         self.appauthor = appauthor
         self.version = version
         self.roaming = roaming
+
     @property
     def user_data_dir(self):
-        return user_data_dir(self.appname, self.appauthor,
-            version=self.version, roaming=self.roaming)
+        return user_data_dir(self.appname, self.appauthor, version=self.version, roaming=self.roaming)
+
     @property
     def site_data_dir(self):
-        return site_data_dir(self.appname, self.appauthor,
-            version=self.version)
+        return site_data_dir(self.appname, self.appauthor, version=self.version)
+
     @property
     def user_cache_dir(self):
-        return user_cache_dir(self.appname, self.appauthor,
-            version=self.version)
+        return user_cache_dir(self.appname, self.appauthor, version=self.version)
+
     @property
     def user_log_dir(self):
-        return user_log_dir(self.appname, self.appauthor,
-            version=self.version)
+        return user_log_dir(self.appname, self.appauthor, version=self.version)
 
 
-
-
-#---- internal support stuff
+# ---- internal support stuff
 
 def _get_win_folder_from_registry(csidl_name):
-    """This is a fallback technique at best. I'm not sure if using the
-    registry for this guarantees us the correct answer for all CSIDL_*
-    names.
+    """
+    This is a fallback technique at best. I'm not sure if using the registry for this guarantees us the correct answer
+    for all CSIDL_* names.
     """
     import _winreg
 
@@ -275,17 +268,20 @@ def _get_win_folder_from_registry(csidl_name):
         "CSIDL_LOCAL_APPDATA": "Local AppData",
     }[csidl_name]
 
-    key = _winreg.OpenKey(_winreg.HKEY_CURRENT_USER,
-        r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders")
+    key = _winreg.OpenKey(
+        _winreg.HKEY_CURRENT_USER,
+        r'Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders'
+    )
     dir, type = _winreg.QueryValueEx(key, shell_folder_name)
     return dir
+
 
 def _get_win_folder_with_pywin32(csidl_name):
     from win32com.shell import shellcon, shell
     dir = shell.SHGetFolderPath(0, getattr(shellcon, csidl_name), 0, 0)
-    # Try to make this a unicode path because SHGetFolderPath does
-    # not return unicode strings when there is unicode data in the
-    # path.
+
+    # Try to make this a unicode path because SHGetFolderPath does not return unicode strings when there is unicode data
+    # in the path.
     try:
         dir = unicode(dir)
 
@@ -305,6 +301,7 @@ def _get_win_folder_with_pywin32(csidl_name):
     except UnicodeError:
         pass
     return dir
+
 
 def _get_win_folder_with_ctypes(csidl_name):
     import ctypes
@@ -332,6 +329,7 @@ def _get_win_folder_with_ctypes(csidl_name):
 
     return buf.value
 
+
 if sys.platform == "win32":
     try:
         import win32com.shell
@@ -344,8 +342,7 @@ if sys.platform == "win32":
             _get_win_folder = _get_win_folder_from_registry
 
 
-
-#---- self test code
+# ---- self test code
 
 if __name__ == "__main__":
     appname = "MyApp"

--- a/binstar_client/utils/config.py
+++ b/binstar_client/utils/config.py
@@ -78,9 +78,11 @@ PACKAGE_TYPE_LABELS = {
 }
 
 PACKAGE_TYPE_ALIASES = {
-    'standard_python': 'pypi',
     'PyPI': 'pypi',
-    'standard_r': 'r'
+    'standard_python': 'pypi',
+
+    'cran': 'r',
+    'standard_r': 'r',
 }
 
 

--- a/binstar_client/utils/detect.py
+++ b/binstar_client/utils/detect.py
@@ -107,8 +107,10 @@ def is_r(filename):
     if filename.endswith('.tar.gz') or filename.endswith('.tgz'):  # Could be a setuptools sdist or r source package
         with tarfile.open(filename) as tf:
 
-            if (any(name.endswith('/DESCRIPTION') for name in tf.getnames()) and
-                any(name.endswith('/NAMESPACE') for name in tf.getnames())):
+            if (
+                    any(name.endswith('/DESCRIPTION') for name in tf.getnames()) and
+                    any(name.endswith('/NAMESPACE') for name in tf.getnames())
+            ):
                 return True
             else:
                 logger.debug("This not is an R package (no '*/DESCRIPTION' and '*/NAMESPACE' files).")

--- a/binstar_client/utils/pprint.py
+++ b/binstar_client/utils/pprint.py
@@ -3,14 +3,21 @@ Created on Aug 8, 2013
 
 @author: sean
 '''
+
 from __future__ import unicode_literals
+from binstar_client.utils import config
 from dateutil.parser import parse as parse_date
 import logging
 
 logger = logging.getLogger('binstar.pprint')
 
-fmt_access = '     %(full_name)-25s | %(latest_version)8s | %(access)-12s | %(package_types)-15s | %(conda_platforms)-15s | %(builds)-10s'
-fmt_no_access = '     %(full_name)-25s | %(latest_version)8s | %(package_types)-15s | %(conda_platforms)-15s | %(builds)-10s'
+fmt_access = (
+    '     %(full_name)-32s | %(latest_version)8s | %(access)-12s | %(package_types)-17s | %(conda_platforms)-15s | '
+    '%(builds)-10s'
+)
+fmt_no_access = (
+    '     %(full_name)-32s | %(latest_version)8s | %(package_types)-17s | %(conda_platforms)-15s | %(builds)-10s'
+)
 
 
 def pprint_orgs(orgs):
@@ -37,22 +44,47 @@ def pprint_package_header(access=True, revisions=False):
     logger.info(fmt % package_header)
 
 
+def format_package_type(value):
+    value = str(value)
+    try:
+        return config.PackageType(value).label()
+    except ValueError:
+        return value
+
+
 def pprint_package(package, access=True, full_name=True, revision=False):
     package = package.copy()
 
-    package['access'] = 'published' if package.get('published') else 'public' if package['public'] else 'private'
+    if package.get('published'):
+        package['access'] = 'published'
+    elif package['public']:
+        package['access'] = 'public'
+    else:
+        package['access'] = 'private'
 
     if package.get('conda_platforms'):
-        package['conda_platforms'] = ', '.join(str(x) for x in package['conda_platforms'] if x is not None)
+        package['conda_platforms'] = ', '.join(
+            str(x)
+            for x in package['conda_platforms']
+            if x is not None
+        )
 
     if not full_name:
         package['full_name'] = package['name']
 
     if package.get('package_types'):
-        package['package_types'] = ', '.join(str(x) for x in package['package_types'] if x is not None)
+        package['package_types'] = ', '.join(
+            format_package_type(x)
+            for x in package['package_types']
+            if x is not None
+        )
 
     if package.get('builds'):
-        package['builds'] = ', '.join(str(x) for x in package['builds'] if x is not None)
+        package['builds'] = ', '.join(
+            str(x)
+            for x in package['builds']
+            if x is not None
+        )
     else:
         package['builds'] = ''
 
@@ -77,11 +109,11 @@ def pprint_packages(packages, access=True, full_name=True, revisions=False):
     pprint_package_header(access, revisions=revisions)
 
     package_header = {
-        'full_name': '-' * 25,
+        'full_name': '-' * 32,
         'access': '-' * 12,
         'latest_version': '-' * 6,
         'conda_platforms': '-' * 15,
-        'package_types': '-' * 15,
+        'package_types': '-' * 17,
         'revision': '-' * 6,
         'builds': '-' * 10
     }


### PR DESCRIPTION
Extensions and cleanups to better support r packages, as well as present "standard python" and "standard r" labels instead of "pypi"/"r".

Dev-tested on a linux-64 machine