### PR TITLE
AS-758: Allow path to upload whl with conda package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ We [keep a changelog.](http://keepachangelog.com/)
 ### Tickets closed
 
 * [AC-150](https://anaconda.atlassian.net/browse/AC-150) - Fix upload of large files
+* [AS-758](https://anaconda.atlassian.net/browse/AS-758) - Anaconda client doesn't allow pypi whl to use conda package names
 
 ### Pull requests merged
 
 * [PR 646](https://github.com/Anaconda-Platform/anaconda-client/pull/646) - AC-150: fix multipart files upload
+* [PR 640](https://github.com/Anaconda-Platform/anaconda-client/pull/640) - AS-758: Allow path to upload whl with conda package name
 
 ## 1.11.1 - 2023-03-01
 

--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -89,12 +89,16 @@ def determine_package_type(filename, args):
 
 def get_package_name(args, package_attrs, package_type):
     if args.package:
-        if 'name' in package_attrs and package_attrs['name'].lower() != args.package.lower():
-            msg = 'Package name on the command line " {}" does not match the package name in the file "{}"'.format(
-                args.package.lower(), package_attrs['name'].lower()
-            )
-            logger.error(msg)
-            raise errors.BinstarError(msg)
+        if 'name' in package_attrs:
+            good_names = [package_attrs['name'].lower()]
+            if package_type == PackageType.STANDARD_PYTHON:
+                good_names.append(good_names[0].replace('-', '_'))
+            if args.package.lower() not in good_names:
+                msg = 'Package name on the command line " {}" does not match the package name in the file "{}"'.format(
+                    args.package.lower(), package_attrs['name'].lower()
+                )
+                logger.error(msg)
+                raise errors.BinstarError(msg)
         package_name = args.package
     else:
         if 'name' not in package_attrs:

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -115,6 +115,59 @@ class Test(CLITestCase):
         self.assertIsNotNone(json.loads(staging_response.req.body).get('sha256'))
 
     @urlpatch
+    def test_upload_pypi_with_conda_package_name_allowed(self, registry):
+        registry.register(method='HEAD', path='/', status=200)
+        registry.register(method='GET', path='/user', content='{"login": "eggs"}')
+        content = {'package_types': ['pypi']}
+        registry.register(method='GET', path='/package/eggs/test_package34', content=content)
+        registry.register(method='GET', path='/release/eggs/test_package34/0.3.1', content='{}')
+        registry.register(method='GET', path='/dist/eggs/test_package34/0.3.1/test_package34-0.3.1.tar.gz', status=404,
+                          content='{}')
+
+        content = {'post_url': 'http://s3url.com/s3_url', 'form_data': {}, 'dist_id': 'dist_id'}
+        staging_response = registry.register(
+            method='POST', path='/stage/eggs/test_package34/0.3.1/test_package34-0.3.1.tar.gz',
+            content=content)
+
+        registry.register(method='POST', path='/s3_url', status=201)
+        registry.register(method='POST', path='/commit/eggs/test_package34/0.3.1/test_package34-0.3.1.tar.gz',
+                          status=200, content={})
+
+        # Pass -o to override the channel/package pypi package should go to
+        main(['--show-traceback', 'upload',
+              '--package', 'test_package34',
+              '--package-type', 'pypi', data_dir('test_package34-0.3.1.tar.gz')], False)
+
+        registry.assertAllCalled()
+        self.assertIsNotNone(json.loads(staging_response.req.body).get('sha256'))
+
+    @urlpatch
+    def test_upload_conda_package_with_name_override_fails(self, registry):
+        registry.register(method='HEAD', path='/', status=200)
+        registry.register(method='GET', path='/user', content='{"login": "eggs"}')
+
+        # Passing -o for `file` package_type doesn't override channel
+        with self.assertRaises(errors.BinstarError):
+            main(['--show-traceback', 'upload',
+                  '--package', 'test_package',
+                  '--package-type', 'file',
+                  data_dir('test_package34-0.3.1.tar.gz')], False)
+
+        registry.assertAllCalled()
+
+    @urlpatch
+    def test_upload_pypi_with_random_name(self, registry):
+        registry.register(method='HEAD', path='/', status=200)
+        registry.register(method='GET', path='/user', content='{"login": "eggs"}')
+
+        with self.assertRaises(errors.BinstarError):
+            main(['--show-traceback', 'upload',
+                  '--package', 'alpha_omega',
+                  data_dir('test_package34-0.3.1.tar.gz')], False)
+
+        registry.assertAllCalled()
+
+    @urlpatch
     def test_upload_file(self, registry):
         registry.register(method='HEAD', path='/', status=200)
         registry.register(method='GET', path='/user', content='{"login": "eggs"}')


### PR DESCRIPTION
When anaconda-client uploads a wheel, it uses the pypi compliant package name. This means it [replaces ‘_' and ‘.' with ‘-’](https://github.com/Anaconda-Platform/anaconda-client/blob/2893410fa23ccd14e514c945a1f0e744adc7cb83/binstar_client/inspect_package/pypi.py#L38-L40). The effect of this is that a separate package is created for any conda packages which have '.’ or '-’ in their name. 

It IS possible to pass the package name as an argument on upload.  However, if the package name that is passed as an argument does not exactly match the name that is normalized for pypi, anaconda-client throws an error:

```
π anaconda upload --package mkl_random --label wheels mkl_random-1.2.2-17-cp39-cp39-macosx_10_10_x86_64.whl
Using Anaconda API: http://localhost:4990/api
Using "foouser" as upload username
Processing 'mkl_random-1.2.2-17-cp39-cp39-macosx_10_10_x86_64.whl'
Detecting file type...
File type is "Standard Python"
Extracting standard python attributes for upload
[ERROR] Package name on the command line " mkl_random" does not match the package name in the file "mkl-random"
```

Adding an option to allow this scenario.