### PR TITLE
AC-149: Use package metadata on upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ We [keep a changelog.](http://keepachangelog.com/)
 
 ### Tickets closed
 
+* [AC-149](https://anaconda.atlassian.net/browse/AC-149) - Add option to use package metadata on upload
 * [AC-150](https://anaconda.atlassian.net/browse/AC-150) - Fix upload of large files
 * [AS-758](https://anaconda.atlassian.net/browse/AS-758) - Anaconda client doesn't allow pypi whl to use conda package names
 
@@ -13,6 +14,7 @@ We [keep a changelog.](http://keepachangelog.com/)
 
 * [PR 647](https://github.com/Anaconda-Platform/anaconda-client/pull/647) - AS-796: linters update
 * [PR 646](https://github.com/Anaconda-Platform/anaconda-client/pull/646) - AC-150: fix multipart files upload
+* [PR 641](https://github.com/Anaconda-Platform/anaconda-client/pull/641) - AC-149: Use package metadata on upload
 * [PR 640](https://github.com/Anaconda-Platform/anaconda-client/pull/640) - AS-758: Allow path to upload whl with conda package name
 
 ## 1.11.1 - 2023-03-01

--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -168,6 +168,10 @@ def add_release(aserver_api, args, username,  # pylint: disable=too-many-argumen
     try:
         # Check if the release already exists
         aserver_api.release(username, package_name, version)
+
+        # If it exists update public attrs if needed.
+        if args.use_package_metadata:
+            aserver_api.update_release(username, package_name, version, release_attrs)
     except errors.NotFound:
         if args.mode == 'interactive':
             create_release_interactive(aserver_api, username, package_name, version, release_attrs)
@@ -477,6 +481,11 @@ def add_parser(subparsers):
         action='store_const',
         dest='mode',
         const='skip',
+    )
+    group.add_argument(
+        '--use-package-metadata',
+        action='store_true',
+        help='Overwrite existing release metadata with the metadata from the package.',
     )
 
     parser.set_defaults(main=main)

--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -170,7 +170,7 @@ def add_release(aserver_api, args, username,  # pylint: disable=too-many-argumen
         aserver_api.release(username, package_name, version)
 
         # If it exists update public attrs if needed.
-        if args.use_package_metadata:
+        if args.force_metadata_update:
             aserver_api.update_release(username, package_name, version, release_attrs)
     except errors.NotFound:
         if args.mode == 'interactive':
@@ -483,7 +483,7 @@ def add_parser(subparsers):
         const='skip',
     )
     group.add_argument(
-        '--use-package-metadata',
+        '-m', '--force-metadata-update',
         action='store_true',
         help='Overwrite existing release metadata with the metadata from the package.',
     )

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -101,7 +101,7 @@ class Test(CLITestCase):
         registry.register(
             method='GET', path='/dist/eggs/mock/2.0.0/osx-64/mock-2.0.0-py37_1000.conda', status=404, content='{}')
 
-        content = {"post_url": "http://s3url.com/s3_url", "form_data": {}, "dist_id": "dist_id"}
+        content = {'post_url': 'http://s3url.com/s3_url', 'form_data': {}, 'dist_id': 'dist_id'}
         staging_response = registry.register(
             method='POST', path='/stage/eggs/mock/2.0.0/osx-64/mock-2.0.0-py37_1000.conda', content=content)
 
@@ -109,7 +109,7 @@ class Test(CLITestCase):
         registry.register(
             method='POST', path='/commit/eggs/mock/2.0.0/osx-64/mock-2.0.0-py37_1000.conda', status=200, content={})
 
-        main(['--show-traceback', 'upload', '--use-package-metadata', data_dir('mock-2.0.0-py37_1000.conda')], False)
+        main(['--show-traceback', 'upload', '--force-metadata-update', data_dir('mock-2.0.0-py37_1000.conda')], False)
 
         registry.assertAllCalled()
         self.assertIsNotNone(json.loads(staging_response.req.body).get('sha256'))

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -91,6 +91,30 @@ class Test(CLITestCase):
         self.assertIsNotNone(json.loads(staging_response.req.body).get('sha256'))
 
     @urlpatch
+    def test_upload_use_pkg_metadata(self, registry):
+        registry.register(method='HEAD', path='/', status=200)
+        registry.register(method='GET', path='/user', content='{"login": "eggs"}')
+        content = {'package_types': ['conda']}
+        registry.register(method='GET', path='/package/eggs/mock', content=content)
+        registry.register(method='GET', path='/release/eggs/mock/2.0.0', content='{}')
+        registry.register(method='PATCH', path='/release/eggs/mock/2.0.0', content='{}')
+        registry.register(
+            method='GET', path='/dist/eggs/mock/2.0.0/osx-64/mock-2.0.0-py37_1000.conda', status=404, content='{}')
+
+        content = {"post_url": "http://s3url.com/s3_url", "form_data": {}, "dist_id": "dist_id"}
+        staging_response = registry.register(
+            method='POST', path='/stage/eggs/mock/2.0.0/osx-64/mock-2.0.0-py37_1000.conda', content=content)
+
+        registry.register(method='POST', path='/s3_url', status=201)
+        registry.register(
+            method='POST', path='/commit/eggs/mock/2.0.0/osx-64/mock-2.0.0-py37_1000.conda', status=200, content={})
+
+        main(['--show-traceback', 'upload', '--use-package-metadata', data_dir('mock-2.0.0-py37_1000.conda')], False)
+
+        registry.assertAllCalled()
+        self.assertIsNotNone(json.loads(staging_response.req.body).get('sha256'))
+
+    @urlpatch
     def test_upload_pypi(self, registry):
         registry.register(method='HEAD', path='/', status=200)
         registry.register(method='GET', path='/user', content='{"login": "eggs"}')


### PR DESCRIPTION
This PR is related to [this conda discussion](https://github.com/conda/infrastructure/discussions/649#discussioncomment-5398665). To sum up, it is not currently possible to upload a new distribution of the same version of a package and have the metadata from the new distribution be applied to the repository.  This story is about adding this capability as an upload option.

Here is the scenario this PR addresses:

1. A package is uploaded: `user_foo/package_bar/1.0.0`.
2. The package has certain `dev_url` and `doc_url` defined in the conda-build meta.yml. These values are reflected on the package's web page.
3. A new release is created with the same metadata (`doc_url`, `dev_url`): `user_foo/package_bar/1.1.0`.  At this point everything is still fine.
4. At some point, the metadata changes (the `dev_url` and `doc_url`), but the package version (`1.1.0`) does not change.
5. A new distribution of the same release number is uploaded. 
 
In the current scenario, the older metadata would persist since this is NOT a new release. This PR empowers users to override the default behavior and designate that the package metadata should be propagated to the backend.

