### PR TITLE
feat: Allow main entrypoint plugin

### DIFF
--- a/binstar_client/scripts/cli.py
+++ b/binstar_client/scripts/cli.py
@@ -162,6 +162,13 @@ def _load_main_plugin():
     else:
         plugin_mains = entry_points().select(group=plugin_group_name)
 
+    if len(plugin_mains) > 1:
+        raise EnvironmentError(
+            'More than one `anaconda_cli.main` plugin is installed. Please ensure only one '
+            'of the following packages are installed:\n\n' +
+            '\n'.join(f'  * {ep.value}' for ep in plugin_mains)
+        )
+
     if plugin_mains:
         return plugin_mains[0].load()
     return None

--- a/binstar_client/scripts/cli.py
+++ b/binstar_client/scripts/cli.py
@@ -149,18 +149,19 @@ def binstar_main(sub_command_module, args=None, exit=True,  # pylint: disable=re
             raise SystemExit(1) from error
         return 1
 
+
 def _load_main_plugin():
     """Allow loading a new CLI main entrypoint via plugin mechanisms. There can only be one."""
     from importlib.metadata import entry_points
     from sys import version_info
 
-    plugin_group_name = "anaconda_cli.main"
+    plugin_group_name = 'anaconda_cli.main'
 
     # The API was changed in Python 3.10, see https://docs.python.org/3/library/importlib.metadata.html#entry-points
     if version_info.major == 3 and version_info.minor <= 9:
         plugin_mains = entry_points()[plugin_group_name]
     else:
-        plugin_mains = entry_points().select(group=plugin_group_name)  # type: ignore
+        plugin_mains = entry_points().select(group=plugin_group_name)
 
     if plugin_mains:
         return plugin_mains[0].load()

--- a/binstar_client/scripts/cli.py
+++ b/binstar_client/scripts/cli.py
@@ -9,6 +9,7 @@ from __future__ import print_function, unicode_literals
 import logging
 import sys
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from importlib.metadata import entry_points
 from logging.handlers import RotatingFileHandler
 from os import makedirs
 from os.path import join, exists, isfile
@@ -152,13 +153,11 @@ def binstar_main(sub_command_module, args=None, exit=True,  # pylint: disable=re
 
 def _load_main_plugin():
     """Allow loading a new CLI main entrypoint via plugin mechanisms. There can only be one."""
-    from importlib.metadata import entry_points
-    from sys import version_info
 
     plugin_group_name = 'anaconda_cli.main'
 
     # The API was changed in Python 3.10, see https://docs.python.org/3/library/importlib.metadata.html#entry-points
-    if version_info.major == 3 and version_info.minor <= 9:
+    if sys.version_info.major == 3 and sys.version_info.minor <= 9:
         plugin_mains = entry_points()[plugin_group_name]
     else:
         plugin_mains = entry_points().select(group=plugin_group_name)

--- a/binstar_client/scripts/cli.py
+++ b/binstar_client/scripts/cli.py
@@ -170,7 +170,7 @@ def _load_main_plugin():
         )
 
     if plugin_mains:
-        # The `.load()` function must be a callable, which is defined inside the package implementing the plugin
+        # The `.load()` function returns a callable, which is defined inside the package implementing the plugin
         # e.g. in pyproject.toml, where my_plugin_library.cli.main is the callable entrypoint function
         # [project.entry-points."anaconda_cli.main"]
         # anaconda = "my_plugin_library.cli:main"

--- a/binstar_client/scripts/cli.py
+++ b/binstar_client/scripts/cli.py
@@ -158,7 +158,7 @@ def _load_main_plugin():
 
     # The API was changed in Python 3.10, see https://docs.python.org/3/library/importlib.metadata.html#entry-points
     if sys.version_info.major == 3 and sys.version_info.minor <= 9:
-        plugin_mains = entry_points()[plugin_group_name]
+        plugin_mains = entry_points().get(plugin_group_name, [])
     else:
         plugin_mains = entry_points().select(group=plugin_group_name)
 

--- a/binstar_client/scripts/cli.py
+++ b/binstar_client/scripts/cli.py
@@ -149,10 +149,31 @@ def binstar_main(sub_command_module, args=None, exit=True,  # pylint: disable=re
             raise SystemExit(1) from error
         return 1
 
+def _load_main_plugin():
+    """Allow loading a new CLI main entrypoint via plugin mechanisms. There can only be one."""
+    from importlib.metadata import entry_points
+    from sys import version_info
 
-def main(args=None, _exit=True):
-    binstar_main(command_module, args, _exit,
-                 description=__doc__, version=version)
+    plugin_group_name = "anaconda_cli.main"
+
+    # The API was changed in Python 3.10, see https://docs.python.org/3/library/importlib.metadata.html#entry-points
+    if version_info.major == 3 and version_info.minor <= 9:
+        plugin_mains = entry_points()[plugin_group_name]
+    else:
+        plugin_mains = entry_points().select(group=plugin_group_name)  # type: ignore
+
+    if plugin_mains:
+        return plugin_mains[0].load()
+    return None
+
+
+def main(args=None, _exit=True, allow_plugin_main=True):
+    plugged_in_main = _load_main_plugin()
+    if allow_plugin_main and plugged_in_main is not None:
+        plugged_in_main()
+    else:
+        binstar_main(command_module, args, _exit,
+                     description=__doc__, version=version)
 
 
 if __name__ == '__main__':

--- a/binstar_client/scripts/cli.py
+++ b/binstar_client/scripts/cli.py
@@ -170,6 +170,10 @@ def _load_main_plugin():
         )
 
     if plugin_mains:
+        # The `.load()` function must be a callable, which is defined inside the package implementing the plugin
+        # e.g. in pyproject.toml, where my_plugin_library.cli.main is the callable entrypoint function
+        # [project.entry-points."anaconda_cli.main"]
+        # anaconda = "my_plugin_library.cli:main"
         return plugin_mains[0].load()
     return None
 


### PR DESCRIPTION
### Summary

Adds the ability for another package to replace the main CLI entrypoint function by defining the plugin entrypoint `anaconda_cli.main`. This allows us to maintain the `anaconda` entrypoint CLI inside `anaconda-client` for as long as we want, and also allows over-riding behavior and supporting additional plugins if another package implementing this plugin is installed into a user's environment.

This change should have no user impact in the case `anaconda-client` is upgraded without having a companion package implementing this plugin. In the design of the package implementing this plugin, we will take care to maintain compatibility and provide appropriate deprecation paths for users who happen to have both installed in an automated setting.

In the very rare case that a user accidentally has two packages implementing this plugin, an `EnvironmentError` is raised.