### PR TITLE
fix logic used to find CONDA_ROOT

### DIFF
--- a/binstar_client/utils/conda.py
+++ b/binstar_client/utils/conda.py
@@ -4,10 +4,11 @@ import json
 import subprocess  # nosec
 import sys
 import os
-from os.path import basename, dirname, join, exists
+from os.path import basename, dirname
 
 
 ENV_PREFIX = sys.prefix
+
 
 # this function is broken out for monkeypatch by unit tests,
 # so we can test the ImportError handling
@@ -17,7 +18,7 @@ def _import_conda_root():
 
 
 def _conda_root_from_conda_info():
-    command = os.environ.get("CONDA_EXE", "conda")
+    command = os.environ.get('CONDA_EXE', 'conda')
     if not command:
         return None
     try:

--- a/binstar_client/utils/conda.py
+++ b/binstar_client/utils/conda.py
@@ -3,14 +3,11 @@
 import json
 import subprocess  # nosec
 import sys
+import os
 from os.path import basename, dirname, join, exists
 
-WINDOWS = sys.platform.startswith('win')
-CONDA_PREFIX = sys.prefix
-BIN_DIR = 'Scripts' if WINDOWS else 'bin'
-CONDA_EXE = join(CONDA_PREFIX, BIN_DIR, 'conda.exe' if WINDOWS else 'conda')
-CONDA_BAT = join(CONDA_PREFIX, BIN_DIR, 'conda.bat')
 
+ENV_PREFIX = sys.prefix
 
 # this function is broken out for monkeypatch by unit tests,
 # so we can test the ImportError handling
@@ -19,25 +16,13 @@ def _import_conda_root():
     return conda.config.root_dir
 
 
-def _get_conda_exe():
-    command = CONDA_EXE
-    if WINDOWS:
-        command = CONDA_EXE if exists(CONDA_EXE) else CONDA_BAT
-
-    if not exists(command):
-        command = None
-
-    return command
-
-
 def _conda_root_from_conda_info():
-    command = _get_conda_exe()
+    command = os.environ.get("CONDA_EXE", "conda")
     if not command:
         return None
-
     try:
         output = subprocess.check_output([
-            command, 'info', '--json'], creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == 'win32' else None
+            command, 'info', '--json'], creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == 'win32' else 0,
         ).decode('utf-8')  # nosec
         conda_info = json.loads(output)
         return conda_info['root_prefix']
@@ -57,7 +42,7 @@ def get_conda_root():
         conda_root = _import_conda_root()
     except ImportError:
         # We're not in the root environment.
-        envs_dir = dirname(CONDA_PREFIX)
+        envs_dir = dirname(ENV_PREFIX)
         if basename(envs_dir) == 'envs':
             # We're in a named environment: `conda create -n <name>`
             conda_root = dirname(envs_dir)

--- a/binstar_client/utils/config.py
+++ b/binstar_client/utils/config.py
@@ -17,14 +17,14 @@ import yaml
 
 from binstar_client.errors import BinstarError
 from binstar_client.utils.appdirs import AppDirs, EnvAppDirs
-from binstar_client.utils.conda import CONDA_PREFIX, CONDA_ROOT
+from binstar_client.utils.conda import ENV_PREFIX, CONDA_ROOT
 from .yaml import yaml_load, yaml_dump
 
 logger = logging.getLogger('binstar')
 
 
 def expandvars(path):
-    environ = {'CONDA_ROOT': CONDA_ROOT, 'CONDA_PREFIX': CONDA_PREFIX}
+    environ = {'CONDA_ROOT': CONDA_ROOT, 'ENV_PREFIX': ENV_PREFIX}
     environ.update(os.environ)
     return Template(path).safe_substitute(**environ)
 
@@ -113,7 +113,7 @@ SEARCH_PATH = (
     '$CONDA_ROOT/etc/anaconda-client/',
     dirs.user_data_dir,
     '~/.continuum/anaconda-client/',
-    '$CONDA_PREFIX/etc/anaconda-client/',
+    '$ENV_PREFIX/etc/anaconda-client/',
 )
 
 


### PR DESCRIPTION
If not in the base/root environment or a named environment use the CONDA_EXE variable to call conda and determine the root prefix. If this variable is not set, fall-back to a 'conda' command which may by on PATH.

When not on Windows set the creationflags parameter to 0.

Rename the CONDA_PREFIX variable to ENV_PREFIX which better represents the path.

fixes #643