### PR TITLE
use conda.gateways.anaconda_client for tokens possible

### DIFF
--- a/binstar_client/utils/config.py
+++ b/binstar_client/utils/config.py
@@ -182,14 +182,14 @@ TOKEN_DIRS = [
 ]
 TOKEN_DIR = TOKEN_DIRS[-1]
 if c_client is not None:
-    conda_token_dir = c_client._get_binstar_token_directory()
+    conda_token_dir = c_client._get_binstar_token_directory()  # pylint: disable=W0212
     if conda_token_dir != TOKEN_DIRS[0]:
         warnings.warn(
             'conda and anaconda-client have conflicting token paths:\n'
             '  conda: %s\n'
             '  anaconda-client: %s\n'
             'to ensure consistent behavior, the conda path will be used.\n' % (conda_token_dir, TOKEN_DIR),
-            RuntimeWarning     
+            RuntimeWarning
         )
         TOKEN_DIRS.insert(0, conda_token_dir)
 


### PR DESCRIPTION
There is a lot of copied code between binstar_client and conda when it comes to token management: loading, storing, and deleting. In theory, this is necessary because it should be possible to use anaconda-client _without_ conda. But the copying means that any mechanisms we might consider to enhance token management in conda will not be picked up in anaconda-client. For instance, for anaconda-ident, we are enabling conda to store tokens within its configuration mechanism. But this mechanism would then be unavailable to anaconda-client.

This PR attempts to drive towards correction by using `conda.gateways.anaconda_client` whenever it is installed in the same environment:
- `c.g.a. _get_binstar_token_directory()` overrides the `TOKEN_DIRS` determination
- `c.g.a.read_binstar_tokens()` is used for `load_token`
- `c.g.a. set_binstar_token()` is used for `store_token`

We are duplicating conda's practice of allowing _prefix matches_ for the URLs corresponding to the token. So, for instance, the token file named `quote_plus("https://anaconda.org/") + ".token"` will match URLs like `https://anaconda.org/api`, `https://anaconda.org/repo`, but not (for instance) `http://test.anaconda.org`.
