### PR TITLE
build: Add requires-python metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setuptools.setup(
         'Programming Language :: Python',
     ],
 
+    python_requires = '>=3.8',
     install_requires=install_requires,
     extras_require={
         'full': extras_require,


### PR DESCRIPTION
Resolves #678

* Add requires-python metadata through the addition of setuptools's python_requires in setup.py.
   - c.f. https://peps.python.org/pep-0621/#requires-python

* The addition of requires-python is to provide guards to keep older CPython versions from installing releases that could contain unrunnable code.