### PR TITLE
Make `arch` and `platform` inside index.json optional

### DIFF
--- a/binstar_client/inspect_package/conda.py
+++ b/binstar_client/inspect_package/conda.py
@@ -101,8 +101,10 @@ def inspect_conda_info_dir(info_path, basename):  # pylint: disable=too-many-loc
         icon_b64 = data_uri_from(icon_path)
 
     subdir = get_subdir(index)
-    machine = index['arch']
-    operatingsystem = os_map.get(index['platform'], index['platform'])
+    machine = index.get('arch', None)
+    platform = index.get('platform', None)
+
+    operatingsystem = os_map.get(platform, platform)
 
     package_data = {
         'name': index.pop('name'),


### PR DESCRIPTION
When a noarch package is built, `conda-build` currently sets the `arch` and `platform` fields to `null`. `rattler-build` does not even include them when a noarch package is built, as they are optional anyway (see https://docs.conda.io/projects/conda-build/en/stable/resources/package-spec.html#repo-si). This PR sets `arch` and `platform` to `null` instead of panicking if the fields are missing.