### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/check-master.yml
+++ b/.github/workflows/check-master.yml
@@ -51,7 +51,7 @@ jobs:
           conda info
           conda config --show
           conda list --show-channel-urls
-          echo "exit_status=success" >> $GITHUB_OUTPUT
+          echo "exit_status=success" >> "$GITHUB_OUTPUT"
 
       - name: Check with pycodestyle
         if: ${{ always() && steps.conda_environment_information.outputs.exit_status == 'success' }}

--- a/.github/workflows/check-master.yml
+++ b/.github/workflows/check-master.yml
@@ -51,7 +51,7 @@ jobs:
           conda info
           conda config --show
           conda list --show-channel-urls
-          echo ::set-output name=exit_status::success
+          echo "exit_status=success" >> $GITHUB_OUTPUT
 
       - name: Check with pycodestyle
         if: ${{ always() && steps.conda_environment_information.outputs.exit_status == 'success' }}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


