### PR TITLE
Restore default user config search path on Linux

### DIFF
--- a/binstar_client/utils/appdirs.py
+++ b/binstar_client/utils/appdirs.py
@@ -18,6 +18,10 @@ class EnvAppDirs:
         return os.path.join(self.root_path, 'data')
 
     @property
+    def user_config_dir(self):
+        return os.path.join(self.root_path, 'data')
+
+    @property
     def site_data_dir(self):
         return os.path.join(self.root_path, 'data')
 

--- a/binstar_client/utils/config.py
+++ b/binstar_client/utils/config.py
@@ -36,7 +36,7 @@ logger = logging.getLogger('binstar')
 
 if 'BINSTAR_CONFIG_DIR' in os.environ:
     dirs = EnvAppDirs(os.environ['BINSTAR_CONFIG_DIR'])
-    USER_CONFIG = os.path.join(dirs.user_data_dir, 'config.yaml')
+    USER_CONFIG = os.path.join(dirs.user_config_dir, 'config.yaml')
 else:
     dirs = PlatformDirs('binstar', 'ContinuumIO')  # type: ignore
     USER_CONFIG = os.path.join(os.path.expanduser('~'), '.continuum', 'anaconda-client', 'config.yaml')
@@ -109,7 +109,7 @@ SEARCH_PATH = (
     dirs.site_data_dir,
     '/etc/anaconda-client/',
     '$CONDA_ROOT/etc/anaconda-client/',
-    dirs.user_data_dir,
+    dirs.user_config_dir,
     '~/.continuum/anaconda-client/',
     '$CONDA_PREFIX/etc/anaconda-client/',
 )
@@ -180,7 +180,7 @@ def get_binstar(args=None, cls=None):
 
 
 TOKEN_DIRS = [
-    dirs.user_data_dir,
+    dirs.user_config_dir,
     os.path.join(os.path.dirname(USER_CONFIG), 'tokens'),
 ]
 TOKEN_DIR = TOKEN_DIRS[-1]


### PR DESCRIPTION
In commit 9ce1897 the vendored appdirs=1.2.0 was replaced with the newer platformdirs implementation.
In appdirs=1.2.0 "user_data_dir" pointed to ~/.config/... on Linux. "user_config_dir" was only introduced in appdirs=1.3.0 and "user_data_dir" points to ~/.local/share/... in those versions. To retain the previous ~/.config/... usage, we now use the semantically better fitting "platformdirs.user_config_dir" instead.

----
The same issue was reported for `conda` by @s22chan in https://github.com/conda/conda/issues/13517 with @jezdez working on a fix in https://github.com/conda/conda/issues/13520 .