### PR TITLE
fix: Ensure `--token` argument is captured in `anaconda --token TOKEN upload`

### DIFF
--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -153,9 +153,6 @@ def _subcommand(ctx: Context) -> None:
     to the binstar_main function.
 
     """
-    # HOTFIX: There is a bug when capturing the full CLI arguments via the typer context.
-    #         For the use case when another plugin is installed, and this code path is
-    #         executed, we will just send the raw CLI arguments to the binstar parser.
     # We use the sys.argv and remove the "org" subcommand, in order to properly handle
     # any CLI flags or parameters passed in before the subcommand,
     # e.g. anaconda -t TOKEN upload ...


### PR DESCRIPTION
## Summary

This change, which will be applied as a hotfix release `1.13.1` fixes #793.

The existing approach did not correctly capture CLI arguments in between `anaconda` and the subcommand. For example: `anaconda --token TOKEN upload ...` would not properly pass `TOKEN` into the subcommand parser.

This change has already been thoroughly tested and integrated into the `main` branch via #737, however are extracted here for hotfix purposes.

Fixes #793