### PR TITLE
fix: Add exception handling to support graceful fallback if server does not support

### DIFF
--- a/binstar_client/commands/login.py
+++ b/binstar_client/commands/login.py
@@ -117,6 +117,9 @@ def interactive_get_token(args, fail_if_already_exists=True):
             # This is the error state before the unified auth support is deployed on anaconda.org
             if e.message == "Bearer token authentication is not enabled":
                 logger.warning("Server does not support unified auth yet, defaulting to legacy login flow")
+            else:
+                # If we don't have a specific error, we just raise it
+                raise
         else:
             return token
 


### PR DESCRIPTION
### Summary

With the inclusion of #797, we will default to the new interactive flow. However, this depends on server-side changes that are not yet deployed to anaconda.org.

This PR adds an exception handling wrapper around the token retrieval function so we can gracefully fall back onto the legacy behavior if the server does not support the Bearer token yet.

This fixes this unhandled exception error: 
<img width="576" height="182" alt="image" src="https://github.com/user-attachments/assets/27fcbb5a-5c61-4d79-896c-280128f52be1" />

And instead will show a warning (that shouldn't occur once the changes are deployed):
<img width="686" height="131" alt="image" src="https://github.com/user-attachments/assets/3cf01411-4398-4222-aaf8-a4b0fbc028df" />

Ticket: [CLI-118](https://anaconda.atlassian.net/browse/CLI-118)

[CLI-118]: https://anaconda.atlassian.net/browse/CLI-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ