### PR TITLE
fix: Remove use of deprecated is_flag argument

### DIFF
--- a/binstar_client/commands/channel.py
+++ b/binstar_client/commands/channel.py
@@ -144,7 +144,6 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
         list_: bool = typer.Option(
             False,
             '--list',
-            is_flag=True,
             help=f'List all {name}s for a user',
             callback=_exclusive_action,
         ),

--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -859,7 +859,7 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             '--label',
             help=label_help.format(deprecation='', label='label'),
         ),
-        progress: bool = typer.Option(True, is_flag=True, help='Show upload progress'),
+        progress: bool = typer.Option(True, help='Show upload progress'),
         user: typing.Optional[str] = typer.Option(
             None,
             '-u',
@@ -903,7 +903,6 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
         thumbnail: typing.Optional[str] = typer.Option(None, help="Notebook's thumbnail image"),
         private: bool = typer.Option(
             False,
-            is_flag=True,
             help='Create the package with private access',
         ),
         register: bool = typer.Option(


### PR DESCRIPTION
### Summary

Removes a `DeprecationWarning` raised when using the new optional CLI parser. The `is_flag` and `flag_value` arguments were removed from typer in [0.13.0](https://typer.tiangolo.com/release-notes/#0130) via https://github.com/fastapi/typer/pull/987

<img width="1280" height="371" alt="image" src="https://github.com/user-attachments/assets/4aee12b4-365b-46a9-8519-2b8bfca60353" />

Ticket: [CLI-119](https://anaconda.atlassian.net/browse/CLI-119)

[CLI-119]: https://anaconda.atlassian.net/browse/CLI-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ