### PR TITLE
fix: Exit early if user elects not to replace existing token

### DIFF
--- a/binstar_client/commands/login.py
+++ b/binstar_client/commands/login.py
@@ -75,6 +75,9 @@ def try_replace_token(authenticate, **kwargs):
             if bool_input('Would you like to continue'):
                 kwargs['fail_if_already_exists'] = False
                 return authenticate(**kwargs)
+            else:
+                # Exit before we try to overwrite the token
+                raise SystemExit(1)
 
         raise
 


### PR DESCRIPTION
## Summary

Currently, if a user has an existing token with the same name stored locally, they are prompted for whether they would like to overwrite the token. If they select "no", then the request is still made and the server error is reported out to the terminal: 
<img width="1078" height="247" alt="image" src="https://github.com/user-attachments/assets/9e444e84-1fe3-4131-8cf7-f888028cbc8b" />

This PR just changes the behavior so that we exit early, instead of making the request. Like this: 
<img width="1069" height="194" alt="image" src="https://github.com/user-attachments/assets/27d9863f-92cb-46ae-98fc-9878616f9505" />

Ticket: [CLI-143](https://anaconda.atlassian.net/browse/CLI-143)

[CLI-143]: https://anaconda.atlassian.net/browse/CLI-143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ