### PR TITLE
fix: Prevent duplicate prompts to overwrite token

### DIFF
--- a/binstar_client/commands/login.py
+++ b/binstar_client/commands/login.py
@@ -122,7 +122,7 @@ def interactive_get_token(args, fail_if_already_exists=True):
                 auth=anaconda_token,
                 application=auth_name,
                 application_url=url,
-                fail_if_already_exists=fail_if_already_exists,
+                fail_if_already_exists=False,  # Overwrite because user has already confirmed
                 hostname=hostname,
             )
         except errors.Unauthorized as e:


### PR DESCRIPTION
### Summary

Disables the second warning and user prompt when user already has a token stored locally.

Without this change, a user who already has an anaconda.org token stored likely would:

* Be prompted first whether to overwrite the local token
* Be prompted again when creating a token with the same name

Since the general pattern is to use the default hostname, with the new auth flow we will implicitly accept that second one if the first is accepted.

Ticket: [CLI-148](https://anaconda.atlassian.net/browse/CLI-148)

[CLI-148]: https://anaconda.atlassian.net/browse/CLI-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ