### PR TITLE
refac: Rename uitls.py -> utils.py

### DIFF
--- a/binstar_client/inspect_package/pypi.py
+++ b/binstar_client/inspect_package/pypi.py
@@ -11,7 +11,7 @@ from os import path
 from packaging.requirements import Requirement
 
 from binstar_client import errors
-from binstar_client.inspect_package.uitls import extract_first, pop_key
+from binstar_client.inspect_package.utils import extract_first, pop_key
 from binstar_client.utils.config import PackageType
 
 

--- a/binstar_client/inspect_package/uitls.py
+++ b/binstar_client/inspect_package/uitls.py
@@ -1,55 +1,24 @@
-from __future__ import print_function, unicode_literals
+# The contents of this module have all been moved to binstar_client.inspect_package.utils
+from binstar_client.deprecations import DEPRECATE_IN_1_15_0, REMOVE_IN_2_0_0, deprecated
 
-from fnmatch import fnmatch
-from zipfile import ZipFile
-from tarfile import TarFile
+from . import utils
 
+__all__ = []
 
-def extract_first(fileobj, pat):
-    if isinstance(fileobj, ZipFile):
-        return zipfile_match_and_extract(fileobj, pat)
-
-    if isinstance(fileobj, TarFile):
-        return tarfile_match_and_extract(fileobj, pat)
-
-    raise TypeError(
-        'Don\'t know how to extract %s file type' % type(fileobj),
+for name in [
+    "extract_first",
+    "tarfile_match_and_extract",
+    "zipfile_match_and_extract",
+    "safe",
+    "get_key",
+    "pop_key",
+]:
+    deprecated.constant(
+        deprecate_in=DEPRECATE_IN_1_15_0,
+        remove_in=REMOVE_IN_2_0_0,
+        constant=name,
+        value=getattr(utils, name),
+        addendum=f"Use `binstar_client.inspect_package.utils.{name}` instead",
     )
 
-
-def zipfile_match_and_extract(zip_file, pat):
-    item_name = next((info.filename for info in zip_file.infolist() if fnmatch(info.filename, pat)), None)
-    if item_name is None:
-        return None
-    return zip_file.read(item_name).decode(errors='ignore')
-
-
-def tarfile_match_and_extract(tar_file, pat):
-    item_name = next((name for name in tar_file.getnames() if fnmatch(name, pat)), None)
-    if not item_name:
-        return None
-
-    file_obj = tar_file.extractfile(item_name)
-    return file_obj.read().decode(errors='ignore')
-
-
-def safe(version):
-    return version.replace('\n', '-').replace('\\', '-').replace('#', '-')
-
-
-def get_key(data, key, *d):
-    value = data.get(key, *d)
-    if value == 'UNKNOWN':
-        if not d:
-            raise KeyError(key)
-        value = d[0]
-    return value
-
-
-def pop_key(data, key, *d):
-    value = data.pop(key, *d)
-    if value == 'UNKNOWN':
-        if not d:
-            raise KeyError(key)
-        value = d[0]
-    return value
+del DEPRECATE_IN_1_15_0, REMOVE_IN_2_0_0, deprecated

--- a/binstar_client/inspect_package/utils.py
+++ b/binstar_client/inspect_package/utils.py
@@ -1,0 +1,53 @@
+from fnmatch import fnmatch
+from zipfile import ZipFile
+from tarfile import TarFile
+
+
+def extract_first(fileobj, pat):
+    if isinstance(fileobj, ZipFile):
+        return zipfile_match_and_extract(fileobj, pat)
+
+    if isinstance(fileobj, TarFile):
+        return tarfile_match_and_extract(fileobj, pat)
+
+    raise TypeError(
+        'Don\'t know how to extract %s file type' % type(fileobj),
+    )
+
+
+def zipfile_match_and_extract(zip_file, pat):
+    item_name = next((info.filename for info in zip_file.infolist() if fnmatch(info.filename, pat)), None)
+    if item_name is None:
+        return None
+    return zip_file.read(item_name).decode(errors='ignore')
+
+
+def tarfile_match_and_extract(tar_file, pat):
+    item_name = next((name for name in tar_file.getnames() if fnmatch(name, pat)), None)
+    if not item_name:
+        return None
+
+    file_obj = tar_file.extractfile(item_name)
+    return file_obj.read().decode(errors='ignore')
+
+
+def safe(version):
+    return version.replace('\n', '-').replace('\\', '-').replace('#', '-')
+
+
+def get_key(data, key, *d):
+    value = data.get(key, *d)
+    if value == 'UNKNOWN':
+        if not d:
+            raise KeyError(key)
+        value = d[0]
+    return value
+
+
+def pop_key(data, key, *d):
+    value = data.pop(key, *d)
+    if value == 'UNKNOWN':
+        if not d:
+            raise KeyError(key)
+        value = d[0]
+    return value


### PR DESCRIPTION
## Summary

Here, we rename the `binstar_client.inspect_package.uitls` module to `binstar_client.inspect_package.utils`, fixing a long-standing typo. The old import paths are deprecated, but still available to prevent breaking changes.