### PR TITLE
chore: Replace jencode function with json= kwarg

### DIFF
--- a/binstar_client/__init__.py
+++ b/binstar_client/__init__.py
@@ -175,8 +175,7 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
             'fail-if-exists': fail_if_already_exists,
         }
 
-        data, headers = jencode(payload)
-        res = self.session.post(url, auth=auth, data=data, headers=headers)
+        res = self.session.post(url, auth=auth, json=payload)
         self._check_response(res)
         res = res.json()
         token = res['token']
@@ -387,8 +386,7 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
 
         payload = {'public': bool(public), 'publish': False, 'public_attrs': dict(attrs or {})}
 
-        data, headers = jencode(payload)
-        res = self.session.post(url, data=data, headers=headers)
+        res = self.session.post(url, json=payload)
         self._check_response(res)
         return res.json()
 
@@ -403,8 +401,7 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
         url = '{}/package/{}/{}'.format(self.domain, login, package_name)
 
         payload = {'public_attrs': dict(attrs)}
-        data, headers = jencode(payload)
-        res = self.session.patch(url, data=data, headers=headers)
+        res = self.session.patch(url, json=payload)
         self._check_response(res)
         return res.json()
 
@@ -419,8 +416,7 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
         """
         url = '{}/release/{}/{}/{}'.format(self.domain, login, package_name, version)
         payload = {'public_attrs': dict(attrs)}
-        data, headers = jencode(payload)
-        res = self.session.patch(url, data=data, headers=headers)
+        res = self.session.patch(url, json=payload)
         self._check_response(res)
         return res.json()
 
@@ -478,8 +474,7 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
         }
         payload.update(release_attrs)
 
-        data, headers = jencode(payload)
-        res = self.session.post(url, data=data, headers=headers)
+        res = self.session.post(url, json=payload)
         self._check_response(res)
         return res.json()
 
@@ -594,8 +589,7 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
             'sha256': sha256,
         }
 
-        data, headers = jencode(payload)
-        res = self.session.post(url, data=data, headers=headers)
+        res = self.session.post(url, json=payload)
         self._check_response(res)
         obj = res.json()
 
@@ -629,8 +623,7 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
 
         url = '%s/commit/%s/%s/%s/%s' % (self.domain, login, package_name, release, quote(basename))
         payload = {'dist_id': obj['dist_id']}
-        data, headers = jencode(payload)
-        res = self.session.post(url, data=data, headers=headers)
+        res = self.session.post(url, json=payload)
         self._check_response(res)
 
         return res.json()

--- a/binstar_client/mixins/channels.py
+++ b/binstar_client/mixins/channels.py
@@ -1,12 +1,3 @@
-"""
-Created on May 2, 2014
-
-@author: sean
-"""
-
-from binstar_client.utils import jencode
-
-
 class ChannelsMixin:
     def list_channels(self, owner):
         """
@@ -43,9 +34,9 @@ class ChannelsMixin:
         :param filename: The exact file to add the channel to
         """
         url = '%s/channels/%s/%s' % (self.domain, owner, channel)
-        data, headers = jencode(package=package, version=version, basename=filename)
+        payload = dict(package=package, version=version, basename=filename)
 
-        res = self.session.post(url, data=data, headers=headers)
+        res = self.session.post(url, json=payload)
         self._check_response(res, [201])
 
     def remove_channel(self, channel, owner, package=None, version=None, filename=None):
@@ -59,9 +50,9 @@ class ChannelsMixin:
         :param filename: The exact file to remove the channel from
         """
         url = '%s/channels/%s/%s' % (self.domain, owner, channel)
-        data, headers = jencode(package=package, version=version, basename=filename)
+        payload = dict(package=package, version=version, basename=filename)
 
-        res = self.session.delete(url, data=data, headers=headers)
+        res = self.session.delete(url, json=payload)
         self._check_response(res, [201])
 
     def copy_channel(self, channel, owner, to_channel):

--- a/binstar_client/mixins/organizations.py
+++ b/binstar_client/mixins/organizations.py
@@ -1,6 +1,3 @@
-from binstar_client.utils import jencode
-
-
 class OrgMixin:
     def user_orgs(self, username=None):
         if username:
@@ -73,7 +70,6 @@ class OrgMixin:
         url = '%s/group/%s/%s' % (self.domain, org, name)
 
         payload = {'perms': perms}
-        data, headers = jencode(payload)
 
-        res = self.session.post(url, data=data, headers=headers)
+        res = self.session.post(url, json=payload)
         self._check_response(res, [204])

--- a/binstar_client/mixins/package.py
+++ b/binstar_client/mixins/package.py
@@ -1,10 +1,3 @@
-"""
-Created on May 23, 2014.
-
-@author: sean
-"""
-
-from binstar_client.utils import jencode
 from binstar_client.errors import Conflict
 
 
@@ -25,14 +18,13 @@ class PackageMixin:
         url = '{}/copy/package/{}'.format(self.domain, copy_path)
 
         payload = {'to_owner': to_owner, 'from_channel': from_label, 'to_channel': to_label}
-        data, headers = jencode(payload)
 
         if replace:
-            res = self.session.put(url, data=data, headers=headers)
+            res = self.session.put(url, json=payload)
         elif update:
-            res = self.session.patch(url, data=data, headers=headers)
+            res = self.session.patch(url, json=payload)
         else:
-            res = self.session.post(url, data=data, headers=headers)
+            res = self.session.post(url, json=payload)
 
         try:
             self._check_response(res)

--- a/binstar_client/utils/__init__.py
+++ b/binstar_client/utils/__init__.py
@@ -24,10 +24,12 @@ from .config import (
     DEFAULT_CONFIG,
 )
 from .spec import PackageSpec, package_specs, parse_specs
+from binstar_client.deprecations import deprecated, DEPRECATE_IN_1_15_0, REMOVE_IN_2_0_0
 
 logger = logging.getLogger('binstar')
 
 
+@deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 def jencode(*E, **F):
     payload = dict(*E, **F)
     return json.dumps(payload), {'Content-Type': 'application/json'}


### PR DESCRIPTION
## Summary

Closes #778 

There was no native `json=` keyword argument when `anaconda-client` was first written. However, now we can just use the argument directly and remove usage of the `jencode()` function.

Here, we do that, and also deprecate the function, for removal.