### PR TITLE
HUB-3368 use organizations paradigm for repo ops

### DIFF
--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -125,6 +125,12 @@ def _resolve_namespace_and_channel(
                 "[red]Error:[/red] No resolvable namespaces. Specify one with --namespace or use namespace/channel format."
             )
             raise typer.Exit(1)
+        username = api.account.get("user", {}).get("username", "")
+        if username:
+            confirm = typer.confirm(f"No organizations found. Use your username '[cyan]{username}[/cyan]' as the namespace?")
+            if confirm:
+                return (username, name)
+            raise typer.Exit(0)
         return (None, name)
 
     if len(namespaces) == 1:
@@ -208,8 +214,22 @@ def create_command(
 
     if public:
         privacy = "public"
-    else:
+    elif private:
         privacy = "private"
+    else:
+        console.print("\nChannel privacy:")
+        console.print("  1. [cyan]private[/cyan]")
+        console.print("  2. [cyan]public[/cyan]")
+        console.print()
+        while True:
+            choice = typer.prompt("Privacy [1-2]", default="1")
+            if choice == "1":
+                privacy = "private"
+                break
+            elif choice == "2":
+                privacy = "public"
+                break
+            console.print("[red]Invalid choice.[/red] Please enter 1 or 2.")
 
     manifest = api.create_namespace_channel(subchannel_name=subchannel, namespace=namespace, privacy=privacy)
     channel_path = manifest["channel_path"]

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -90,9 +90,30 @@ def _callback(
         raise typer.Exit(1)
 
 
+def _resolve_no_namespaces(api, name: str) -> tuple[Optional[str], str]:
+    """Resolve no namespaces case
+
+    Returns (namespace, channel_name).
+
+    Checks for username:
+      1. If None return empty namespace
+      2. If truthy ask user to confirm creation of new namespace
+    
+    """
+    try:
+        username = api.account.get("user", {}).get("username", "") or ""
+    except Exception:
+        return (None, name)
+    
+    confirm = typer.confirm(f"No namespaces found. Use your username '{username}' as the namespace?")
+    if confirm:
+        return (username, name)
+    raise typer.Exit(0)
+
+
 def _resolve_namespace_and_channel(
     api, name: str, namespace: Optional[str] = None, require_namespace: bool = True
-) -> tuple:
+) -> tuple[Optional[str], str]:
     """Resolve namespace and channel name from the given inputs.
 
     Returns (namespace, channel_name). namespace may be None if require_namespace=False
@@ -103,6 +124,7 @@ def _resolve_namespace_and_channel(
       2. name contains "/" → split into namespace/channel
       3. --namespace provided → use it, name is the channel
       4. Neither → resolve namespace from API via user's top-level channels
+      5. Calls _resolve_no_namespaces if none are present
     """
     if "/" in name and namespace:
         console.print("[red]Error:[/red] Ambiguous: name contains '/' but --namespace was also provided.")
@@ -125,16 +147,8 @@ def _resolve_namespace_and_channel(
                 "[red]Error:[/red] No resolvable namespaces. Specify one with --namespace or use namespace/channel format."
             )
             raise typer.Exit(1)
-        try:
-            username = api.account.get("user", {}).get("username", "") or ""
-        except Exception:
-            username = ""
-        if username:
-            confirm = typer.confirm(f"No organizations found. Use your username '{username}' as the namespace?")
-            if confirm:
-                return (username, name)
-            raise typer.Exit(0)
-        return (None, name)
+        
+        return _resolve_no_namespaces(api, name)
 
     if len(namespaces) == 1:
         return (namespaces[0], name)

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -125,9 +125,12 @@ def _resolve_namespace_and_channel(
                 "[red]Error:[/red] No resolvable namespaces. Specify one with --namespace or use namespace/channel format."
             )
             raise typer.Exit(1)
-        username = api.account.get("user", {}).get("username", "")
+        try:
+            username = api.account.get("user", {}).get("username", "") or ""
+        except Exception:
+            username = ""
         if username:
-            confirm = typer.confirm(f"No organizations found. Use your username '[cyan]{username}[/cyan]' as the namespace?")
+            confirm = typer.confirm(f"No organizations found. Use your username '{username}' as the namespace?")
             if confirm:
                 return (username, name)
             raise typer.Exit(0)

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -315,9 +315,9 @@ def modify_command(
     ctx: typer.Context,
     name: str = typer.Argument(..., help="Channel name to modify"),
     namespace: Optional[str] = typer.Option(None, "--namespace", "-n", help="Namespace the channel belongs to"),
-    privacy: Optional[str] = typer.Option(None, "--privacy", help="Set channel privacy: public or private"),
+    privacy: Optional[str] = typer.Option(None, "--privacy", "-p", help="Set channel privacy: public or private"),
     indexing_behavior: Optional[str] = typer.Option(
-        None, "--indexing-behavior", help="Set indexing behavior: default or frozen"
+        None, "--indexing-behavior", "-i", help="Set indexing behavior: default or frozen"
     ),
 ) -> None:
     """Modify channel settings (privacy, indexing behavior)."""

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -309,7 +309,7 @@ def modify_command(
     name: str = typer.Argument(..., help="Channel name to modify"),
     namespace: Optional[str] = typer.Option(None, "--namespace", "-n", help="Namespace the channel belongs to"),
     privacy: Optional[str] = typer.Option(
-        None, "--privacy", help="Set channel privacy: public, authenticated, or private"
+        None, "--privacy", help="Set channel privacy: public or private"
     ),
     indexing_behavior: Optional[str] = typer.Option(
         None, "--indexing-behavior", help="Set indexing behavior: default or frozen"

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -90,7 +90,7 @@ def _callback(
         raise typer.Exit(1)
 
 
-def _resolve_no_namespaces(api, name: str) -> tuple[Optional[str], str]:
+def _resolve_no_namespace(api, name: str) -> tuple[Optional[str], str]:
     """Resolve no namespaces case
 
     Returns (namespace, channel_name).
@@ -128,7 +128,7 @@ def _resolve_namespace_and_channel(
       2. name contains "/" → split into namespace/channel
       3. --namespace provided → use it, name is the channel
       4. Neither → resolve namespace from API via user's top-level channels
-      5. Calls _resolve_no_namespaces if none are present
+      5. Calls _resolve_no_namespace if none are present
     """
     if "/" in name and namespace:
         console.print("[red]Error:[/red] Ambiguous: name contains '/' but --namespace was also provided.")
@@ -152,7 +152,7 @@ def _resolve_namespace_and_channel(
             )
             raise typer.Exit(1)
 
-        return _resolve_no_namespaces(api, name)
+        return _resolve_no_namespace(api, name)
 
     if len(namespaces) == 1:
         return (namespaces[0], name)
@@ -228,17 +228,15 @@ def create_command(
     namespace, channel = _resolve_namespace_and_channel(api, name, namespace, require_namespace=False)
 
     if public:
-        is_private = False
+        privacy = "public"
     elif private:
-        is_private = True
+        privacy = "private"
     else:
         console.print()
-        choice = select_from_list("Channel privacy:", ["private", "public"])
-        is_private = choice == "private"
-    response = api.create_namespace_channel(channel_name=channel, namespace=namespace, private=is_private)
-    privacy_label = "private" if is_private else "public"
+        privacy = select_from_list("Channel privacy:", ["private", "public"])
+    response = api.create_namespace_channel(channel_name=channel, namespace=namespace, private=privacy)
     console.print(
-        f"[green]Success![/green] Channel '[cyan]{response['channel_path']}[/cyan]' created ({privacy_label})."
+        f"[green]Success![/green] Channel '[cyan]{response['channel_path']}[/cyan]' created ({privacy})."
     )
 
 

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -93,7 +93,7 @@ def _callback(
 def _resolve_no_namespace(api, name: str) -> ResolvedChannel:
     """Resolve no namespaces case
 
-    Returns (namespace, channel_name).
+    Returns ResolvedChannel with namespace and channel_name.
 
     Checks for username:
       1. If None or get user request errors, return empty namespace
@@ -110,9 +110,9 @@ def _resolve_no_namespace(api, name: str) -> ResolvedChannel:
             f"No namespaces found. A namespace can be created with your username. Use your username '{username}' as the namespace?"
         )
         if confirm:
-            return (username, name)
+            return ResolvedChannel(namespace=username, channel_name=name)
         raise typer.Exit(0)
-    return (None, name)  # return for errored or empty username
+    return ResolvedChannel(namespace=None, channel_name=name)
 
 
 def _resolve_namespace_and_channel(
@@ -120,7 +120,7 @@ def _resolve_namespace_and_channel(
 ) -> ResolvedChannel:
     """Resolve namespace and channel name from the given inputs.
 
-    Returns (namespace, channel_name). namespace may be None if require_namespace=False
+    Returns ResolvedChannel with namespace and channel_name. namespace may be None if require_namespace=False
     and no namespaces are available (lets create delegate to the API).
 
     Resolution order:
@@ -136,10 +136,10 @@ def _resolve_namespace_and_channel(
 
     if "/" in name:
         parts = name.split("/", 1)
-        return (parts[0], parts[1])
+        return ResolvedChannel(namespace=parts[0], channel_name=parts[1])
 
     if namespace:
-        return (namespace, name)
+        return ResolvedChannel(namespace=namespace, channel_name=name)
 
     # Resolve from API
     orgs = api.list_user_organizations()
@@ -155,11 +155,11 @@ def _resolve_namespace_and_channel(
         return _resolve_no_namespace(api, name)
 
     if len(namespaces) == 1:
-        return (namespaces[0], name)
+        return ResolvedChannel(namespace=namespaces[0], channel_name=name)
 
     console.print()
     selected_namespace = select_from_list("Select namespace:", namespaces)
-    return (selected_namespace, name)
+    return ResolvedChannel(namespace=selected_namespace, channel_name=name)
 
 
 @app.command(name="list", help="List all channels")
@@ -225,7 +225,7 @@ def create_command(
         raise typer.Exit(1)
 
     api = ctx.obj.repo_api
-    namespace, channel = _resolve_namespace_and_channel(api, name, namespace, require_namespace=False)
+    resolved = _resolve_namespace_and_channel(api, name, namespace, require_namespace=False)
 
     if public:
         privacy = "public"
@@ -234,7 +234,7 @@ def create_command(
     else:
         console.print()
         privacy = select_from_list("Channel privacy:", ["private", "public"])
-    response = api.create_namespace_channel(channel_name=channel, namespace=namespace, privacy=privacy)
+    response = api.create_namespace_channel(channel_name=resolved.channel_name, namespace=resolved.namespace, privacy=privacy)
     console.print(f"[green]Success![/green] Channel '[cyan]{response['channel_path']}[/cyan]' created ({privacy}).")
 
 
@@ -246,8 +246,8 @@ def remove_command(
 ) -> None:
     """Remove a channel."""
     api = ctx.obj.repo_api
-    ns, channel = _resolve_namespace_and_channel(api, name, namespace)
-    qualified = f"{ns}/{channel}"
+    resolved = _resolve_namespace_and_channel(api, name, namespace)
+    qualified = f"{resolved.namespace}/{resolved.channel_name}"
     api.remove_channel(qualified)
     console.print(f"[green]Success![/green] Channel '[cyan]{qualified}[/cyan]' removed.")
 
@@ -261,8 +261,8 @@ def show_command(
 ) -> None:
     """Show information about a channel."""
     api = ctx.obj.repo_api
-    ns, channel = _resolve_namespace_and_channel(api, name, namespace)
-    name = f"{ns}/{channel}"
+    resolved = _resolve_namespace_and_channel(api, name, namespace)
+    name = f"{resolved.namespace}/{resolved.channel_name}"
     channel_data = api.get_namespace_channel(name)
 
     subchannels_response = None
@@ -335,8 +335,8 @@ def modify_command(
         raise typer.Exit(1)
 
     api = ctx.obj.repo_api
-    ns, channel = _resolve_namespace_and_channel(api, name, namespace)
-    name = f"{ns}/{channel}"
+    resolved = _resolve_namespace_and_channel(api, name, namespace)
+    name = f"{resolved.namespace}/{resolved.channel_name}"
 
     if privacy:
         api.update_channel(name, privacy=privacy)

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -184,7 +184,11 @@ def list_command(
 
         sub_offset = 0
         while True:
-            channels = api.get_channel_subchannels(org.name, offset=sub_offset, limit=_PAGE_SIZE)
+            try:
+                channels = api.get_channel_subchannels(org.name, offset=sub_offset, limit=_PAGE_SIZE)
+            except Exception:
+                # Namespace may not have any channels yet in the repo
+                break
             for channel in channels:
                 table.add_row(
                     f"  {org.name}/{channel.name}",
@@ -222,15 +226,16 @@ def create_command(
     namespace, channel = _resolve_namespace_and_channel(api, name, namespace, require_namespace=False)
 
     if public:
-        privacy = "public"
+        is_private = False
     elif private:
-        privacy = "private"
+        is_private = True
     else:
         console.print()
-        privacy = select_from_list("Channel privacy:", ["private", "public"])
-
-    response = api.create_namespace_channel(channel_name=channel, namespace=namespace, privacy=privacy)
-    console.print(f"[green]Success![/green] Channel '[cyan]{response['channel_path']}[/cyan]' created ({privacy}).")
+        choice = select_from_list("Channel privacy:", ["private", "public"])
+        is_private = choice == "private"
+    response = api.create_namespace_channel(channel_name=channel, namespace=namespace, private=is_private)
+    privacy_label = "private" if is_private else "public"
+    console.print(f"[green]Success![/green] Channel '[cyan]{response['channel_path']}[/cyan]' created ({privacy_label}).")
 
 
 @app.command(name="remove", help="Remove a channel")

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -237,7 +237,9 @@ def create_command(
         is_private = choice == "private"
     response = api.create_namespace_channel(channel_name=channel, namespace=namespace, private=is_private)
     privacy_label = "private" if is_private else "public"
-    console.print(f"[green]Success![/green] Channel '[cyan]{response['channel_path']}[/cyan]' created ({privacy_label}).")
+    console.print(
+        f"[green]Success![/green] Channel '[cyan]{response['channel_path']}[/cyan]' created ({privacy_label})."
+    )
 
 
 @app.command(name="remove", help="Remove a channel")

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -98,7 +98,7 @@ def _resolve_no_namespaces(api, name: str) -> tuple[Optional[str], str]:
     Checks for username:
       1. If None or get user request errors, return empty namespace
       2. If truthy ask user to confirm creation of new namespace
-    
+
     """
     try:
         username = api.account.get("user", {}).get("username", "") or ""
@@ -106,7 +106,9 @@ def _resolve_no_namespaces(api, name: str) -> tuple[Optional[str], str]:
         username = ""
 
     if username:
-        confirm = typer.confirm(f"No namespaces found. A namespace can be created with your username. Use your username '{username}' as the namespace?")
+        confirm = typer.confirm(
+            f"No namespaces found. A namespace can be created with your username. Use your username '{username}' as the namespace?"
+        )
         if confirm:
             return (username, name)
         raise typer.Exit(0)
@@ -308,9 +310,7 @@ def modify_command(
     ctx: typer.Context,
     name: str = typer.Argument(..., help="Channel name to modify"),
     namespace: Optional[str] = typer.Option(None, "--namespace", "-n", help="Namespace the channel belongs to"),
-    privacy: Optional[str] = typer.Option(
-        None, "--privacy", help="Set channel privacy: public or private"
-    ),
+    privacy: Optional[str] = typer.Option(None, "--privacy", help="Set channel privacy: public or private"),
     indexing_behavior: Optional[str] = typer.Option(
         None, "--indexing-behavior", help="Set indexing behavior: default or frozen"
     ),

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -13,7 +13,7 @@ from rich.panel import Panel
 
 from anaconda_cli_base.console import Table, console, select_from_list
 from binstar_client import __version__
-from binstar_client.repocore import RepoCoreClient
+from binstar_client.repocore import RepoCoreClient, ResolvedChannel
 
 _PAGE_SIZE = 100
 
@@ -90,7 +90,7 @@ def _callback(
         raise typer.Exit(1)
 
 
-def _resolve_no_namespace(api, name: str) -> tuple[Optional[str], str]:
+def _resolve_no_namespace(api, name: str) -> ResolvedChannel:
     """Resolve no namespaces case
 
     Returns (namespace, channel_name).
@@ -117,7 +117,7 @@ def _resolve_no_namespace(api, name: str) -> tuple[Optional[str], str]:
 
 def _resolve_namespace_and_channel(
     api, name: str, namespace: Optional[str] = None, require_namespace: bool = True
-) -> tuple[Optional[str], str]:
+) -> ResolvedChannel:
     """Resolve namespace and channel name from the given inputs.
 
     Returns (namespace, channel_name). namespace may be None if require_namespace=False

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -235,9 +235,7 @@ def create_command(
         console.print()
         privacy = select_from_list("Channel privacy:", ["private", "public"])
     response = api.create_namespace_channel(channel_name=channel, namespace=namespace, private=privacy)
-    console.print(
-        f"[green]Success![/green] Channel '[cyan]{response['channel_path']}[/cyan]' created ({privacy})."
-    )
+    console.print(f"[green]Success![/green] Channel '[cyan]{response['channel_path']}[/cyan]' created ({privacy}).")
 
 
 @app.command(name="remove", help="Remove a channel")

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -187,7 +187,7 @@ def list_command(
         sub_offset = 0
         while True:
             try:
-                channels = api.get_channel_subchannels(org.name, offset=sub_offset, limit=_PAGE_SIZE)
+                channels = api.get_channels(org.name, offset=sub_offset, limit=_PAGE_SIZE)
             except Exception:
                 # Namespace may not have any channels yet in the repo
                 break
@@ -267,11 +267,11 @@ def show_command(
     api = ctx.obj.repo_api
     ns, channel = _resolve_namespace_and_channel(api, name, namespace)
     name = f"{ns}/{channel}"
-    channel_data = api.get_channel(name)
+    channel_data = api.get_namespace_channel(name)
 
     subchannels_response = None
     if full_details and not api.is_subchannel(name):
-        subchannels_response = api.get_channel_subchannels(name)
+        subchannels_response = api.get_channels(name)
 
     table = Table(show_header=False, box=None, padding=(0, 2))
     table.add_column("Field", style="bold cyan")

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -11,7 +11,7 @@ from typing import Optional, Tuple
 import typer
 from rich.panel import Panel
 
-from anaconda_cli_base.console import Table, console
+from anaconda_cli_base.console import Table, console, select_from_list
 from binstar_client import __version__
 from binstar_client.repocore import RepoCoreClient
 
@@ -96,19 +96,21 @@ def _resolve_no_namespaces(api, name: str) -> tuple[Optional[str], str]:
     Returns (namespace, channel_name).
 
     Checks for username:
-      1. If None return empty namespace
+      1. If None or get user request errors, return empty namespace
       2. If truthy ask user to confirm creation of new namespace
     
     """
     try:
         username = api.account.get("user", {}).get("username", "") or ""
     except Exception:
-        return (None, name)
-    
-    confirm = typer.confirm(f"No namespaces found. Use your username '{username}' as the namespace?")
-    if confirm:
-        return (username, name)
-    raise typer.Exit(0)
+        username = ""
+
+    if username:
+        confirm = typer.confirm(f"No namespaces found. A namespace can be created with your username. Use your username '{username}' as the namespace?")
+        if confirm:
+            return (username, name)
+        raise typer.Exit(0)
+    return (None, name)  # return for errored or empty username
 
 
 def _resolve_namespace_and_channel(
@@ -139,7 +141,7 @@ def _resolve_namespace_and_channel(
 
     # Resolve from API
     orgs = api.list_user_organizations()
-    namespaces = [org.get("name", "") for org in orgs]
+    namespaces = [org.name for org in orgs]
 
     if not namespaces:
         if require_namespace:
@@ -147,23 +149,15 @@ def _resolve_namespace_and_channel(
                 "[red]Error:[/red] No resolvable namespaces. Specify one with --namespace or use namespace/channel format."
             )
             raise typer.Exit(1)
-        
+
         return _resolve_no_namespaces(api, name)
 
     if len(namespaces) == 1:
         return (namespaces[0], name)
 
-    console.print("\nMultiple namespaces available:")
-    for i, ns in enumerate(namespaces, 1):
-        console.print(f"  {i}. [cyan]{ns}[/cyan]")
     console.print()
-
-    options = {str(i): ns for i, ns in enumerate(namespaces, 1)}
-    while True:
-        choice = typer.prompt(f"Namespace [1-{len(namespaces)}]")
-        if choice in options:
-            return (options[choice], name)
-        console.print(f"[red]Invalid choice.[/red] Please enter 1-{len(namespaces)}.")
+    selected_namespace = select_from_list("Select namespace:", namespaces)
+    return (selected_namespace, name)
 
 
 @app.command(name="list", help="List all channels")
@@ -176,7 +170,7 @@ def list_command(
     orgs = api.list_user_organizations()
 
     if namespace:
-        orgs = [org for org in orgs if org.get("name", "") == namespace]
+        orgs = [org for org in orgs if org.name == namespace]
 
     table = Table(title="Channels")
     table.add_column("Namespace / Channel", style="cyan")
@@ -186,24 +180,22 @@ def list_command(
     table.add_column("Downloads", justify="right")
 
     for org in orgs:
-        org_name = org.get("name", "")
-        table.add_row(org_name, "", "", "", "")
+        table.add_row(org.name, "", "", "", "")
 
         sub_offset = 0
         while True:
-            subchannels = api.get_channel_subchannels(org_name, offset=sub_offset, limit=_PAGE_SIZE)
-            items = subchannels.get("items", [])
-            for sub in items:
+            channels = api.get_channel_subchannels(org.name, offset=sub_offset, limit=_PAGE_SIZE)
+            for channel in channels:
                 table.add_row(
-                    f"  {org_name}/{sub.get('name', '')}",
-                    sub.get("privacy", ""),
-                    sub.get("description", "") or "",
-                    str(sub.get("artifact_count", 0)),
-                    str(sub.get("download_count", 0)),
+                    f"  {org.name}/{channel.name}",
+                    channel.privacy,
+                    channel.description,
+                    str(channel.artifact_count),
+                    str(channel.download_count),
                 )
-            if len(items) < _PAGE_SIZE:
+            if len(channels) < _PAGE_SIZE:
                 break
-            sub_offset += len(items)
+            sub_offset += len(channels)
 
     if console.height and table.row_count > console.height:
         with console.pager():
@@ -227,30 +219,18 @@ def create_command(
         raise typer.Exit(1)
 
     api = ctx.obj.repo_api
-    namespace, subchannel = _resolve_namespace_and_channel(api, name, namespace, require_namespace=False)
+    namespace, channel = _resolve_namespace_and_channel(api, name, namespace, require_namespace=False)
 
     if public:
         privacy = "public"
     elif private:
         privacy = "private"
     else:
-        console.print("\nChannel privacy:")
-        console.print("  1. [cyan]private[/cyan]")
-        console.print("  2. [cyan]public[/cyan]")
         console.print()
-        while True:
-            choice = typer.prompt("Privacy [1-2]", default="1")
-            if choice == "1":
-                privacy = "private"
-                break
-            elif choice == "2":
-                privacy = "public"
-                break
-            console.print("[red]Invalid choice.[/red] Please enter 1 or 2.")
+        privacy = select_from_list("Channel privacy:", ["private", "public"])
 
-    manifest = api.create_namespace_channel(subchannel_name=subchannel, namespace=namespace, privacy=privacy)
-    channel_path = manifest["channel_path"]
-    console.print(f"[green]Success![/green] Channel '[cyan]{channel_path}[/cyan]' created ({privacy}).")
+    response = api.create_namespace_channel(channel_name=channel, namespace=namespace, privacy=privacy)
+    console.print(f"[green]Success![/green] Channel '[cyan]{response['channel_path']}[/cyan]' created ({privacy}).")
 
 
 @app.command(name="remove", help="Remove a channel")
@@ -280,50 +260,47 @@ def show_command(
     name = f"{ns}/{channel}"
     channel_data = api.get_channel(name)
 
+    subchannels_response = None
     if full_details and not api.is_subchannel(name):
-        channel_data["subchannels"] = api.get_channel_subchannels(name)
+        subchannels_response = api.get_channel_subchannels(name)
 
     table = Table(show_header=False, box=None, padding=(0, 2))
     table.add_column("Field", style="bold cyan")
     table.add_column("Value")
 
     fields = [
-        ("Name", channel_data.get("name", "")),
-        ("Description", channel_data.get("description", "") or ""),
-        ("Privacy", channel_data.get("privacy", "")),
-        ("Artifacts", str(channel_data.get("artifact_count", 0))),
-        ("Downloads", str(channel_data.get("download_count", 0))),
-        ("Mirrors", str(channel_data.get("mirror_count", 0))),
-        ("Subchannels", str(channel_data.get("subchannel_count", 0))),
-        ("Indexing", channel_data.get("indexing_behavior", "")),
-        ("Created", channel_data.get("created", "")),
-        ("Updated", channel_data.get("updated", "")),
+        ("Name", channel_data.name),
+        ("Description", channel_data.description),
+        ("Privacy", channel_data.privacy),
+        ("Artifacts", str(channel_data.artifact_count)),
+        ("Downloads", str(channel_data.download_count)),
+        ("Mirrors", str(channel_data.mirror_count)),
+        ("Indexing", channel_data.indexing_behavior),
+        ("Created", channel_data.created),
+        ("Updated", channel_data.updated),
     ]
 
-    owners = [o for o in channel_data.get("owners", []) if o]
-    if owners:
-        fields.append(("Owners", ", ".join(owners)))
+    if channel_data.owners:
+        fields.append(("Owners", ", ".join(channel_data.owners)))
 
     for field, value in fields:
         table.add_row(field, str(value))
 
     console.print(Panel(table, title=f"Channel: {name}", border_style="green"))
 
-    if full_details and "subchannels" in channel_data:
-        subchannels = channel_data["subchannels"].get("items", [])
-        if subchannels:
-            console.print("\n[bold]Subchannels:[/bold]")
-            sub_table = Table()
-            sub_table.add_column("Name", style="cyan")
-            sub_table.add_column("Privacy")
-            sub_table.add_column("Artifacts", justify="right")
-            for sub in subchannels:
-                sub_table.add_row(
-                    sub.get("name", ""),
-                    sub.get("privacy", ""),
-                    str(sub.get("artifact_count", 0)),
-                )
-            console.print(sub_table)
+    if subchannels_response:
+        console.print("\n[bold]Subchannels:[/bold]")
+        sub_table = Table()
+        sub_table.add_column("Name", style="cyan")
+        sub_table.add_column("Privacy")
+        sub_table.add_column("Artifacts", justify="right")
+        for sub in subchannels_response:
+            sub_table.add_row(
+                sub.name,
+                sub.privacy,
+                str(sub.artifact_count),
+            )
+        console.print(sub_table)
 
 
 @app.command(name="modify", help="Modify channel settings")

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -116,8 +116,8 @@ def _resolve_namespace_and_channel(
         return (namespace, name)
 
     # Resolve from API
-    data = api.list_user_channels(offset=0, limit=100)
-    namespaces = [ch.get("name", "") for ch in data.get("items", [])]
+    orgs = api.list_user_organizations()
+    namespaces = [org.get("name", "") for org in orgs]
 
     if not namespaces:
         if require_namespace:
@@ -147,16 +147,13 @@ def _resolve_namespace_and_channel(
 def list_command(
     ctx: typer.Context,
     namespace: Optional[str] = typer.Option(None, "--namespace", "-n", help="Filter to a specific namespace"),
-    offset: int = typer.Option(0, "--offset", "-o", help="Offset when displaying results"),
-    limit: int = typer.Option(50, "--limit", "-l", help="Limit when displaying results"),
 ) -> None:
     """List all channels for the current user."""
     api = ctx.obj.repo_api
-    data = api.list_user_channels(offset, limit)
+    orgs = api.list_user_organizations()
 
-    channels = data.get("items", [])
     if namespace:
-        channels = [ch for ch in channels if ch.get("name", "") == namespace]
+        orgs = [org for org in orgs if org.get("name", "") == namespace]
 
     table = Table(title="Channels")
     table.add_column("Namespace / Channel", style="cyan")
@@ -165,31 +162,25 @@ def list_command(
     table.add_column("Artifacts", justify="right")
     table.add_column("Downloads", justify="right")
 
-    for ch in channels:
-        channel_name = ch.get("name", "")
-        table.add_row(
-            channel_name,
-            ch.get("privacy", ""),
-            ch.get("description", "") or "",
-            str(ch.get("artifact_count", 0)),
-            str(ch.get("download_count", 0)),
-        )
-        if ch.get("subchannel_count", 0) > 0:
-            sub_offset = 0
-            while True:
-                subchannels = api.get_channel_subchannels(channel_name, offset=sub_offset, limit=_PAGE_SIZE)
-                items = subchannels.get("items", [])
-                for sub in items:
-                    table.add_row(
-                        f"  {channel_name}/{sub.get('name', '')}",
-                        sub.get("privacy", ""),
-                        sub.get("description", "") or "",
-                        str(sub.get("artifact_count", 0)),
-                        str(sub.get("download_count", 0)),
-                    )
-                if len(items) < _PAGE_SIZE:
-                    break
-                sub_offset += len(items)
+    for org in orgs:
+        org_name = org.get("name", "")
+        table.add_row(org_name, "", "", "", "")
+
+        sub_offset = 0
+        while True:
+            subchannels = api.get_channel_subchannels(org_name, offset=sub_offset, limit=_PAGE_SIZE)
+            items = subchannels.get("items", [])
+            for sub in items:
+                table.add_row(
+                    f"  {org_name}/{sub.get('name', '')}",
+                    sub.get("privacy", ""),
+                    sub.get("description", "") or "",
+                    str(sub.get("artifact_count", 0)),
+                    str(sub.get("download_count", 0)),
+                )
+            if len(items) < _PAGE_SIZE:
+                break
+            sub_offset += len(items)
 
     if console.height and table.row_count > console.height:
         with console.pager():

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -101,7 +101,7 @@ def _resolve_no_namespace(api, name: str) -> tuple[Optional[str], str]:
 
     """
     try:
-        username = api.account.get("user", {}).get("username", "") or ""
+        username = (api.account.get("user") or {}).get("username") or ""
     except Exception:
         username = ""
 
@@ -234,7 +234,7 @@ def create_command(
     else:
         console.print()
         privacy = select_from_list("Channel privacy:", ["private", "public"])
-    response = api.create_namespace_channel(channel_name=channel, namespace=namespace, private=privacy)
+    response = api.create_namespace_channel(channel_name=channel, namespace=namespace, privacy=privacy)
     console.print(f"[green]Success![/green] Channel '[cyan]{response['channel_path']}[/cyan]' created ({privacy}).")
 
 

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -234,7 +234,9 @@ def create_command(
     else:
         console.print()
         privacy = select_from_list("Channel privacy:", ["private", "public"])
-    response = api.create_namespace_channel(channel_name=resolved.channel_name, namespace=resolved.namespace, privacy=privacy)
+    response = api.create_namespace_channel(
+        channel_name=resolved.channel_name, namespace=resolved.namespace, privacy=privacy
+    )
     console.print(f"[green]Success![/green] Channel '[cyan]{response['channel_path']}[/cyan]' created ({privacy}).")
 
 

--- a/binstar_client/repocore/__init__.py
+++ b/binstar_client/repocore/__init__.py
@@ -1,5 +1,18 @@
 """Repocore API client for Anaconda repository channel management."""
 
-from binstar_client.repocore.client import RepoCoreClient, UPLOAD_TYPE_MAPPING, API_PATH, AUTH_API_PATH
+from binstar_client.repocore.client import REPO_API_PATH, AUTH_API_PATH, RepoCoreClient, UPLOAD_TYPE_MAPPING
+from binstar_client.repocore.models import (
+    Channel,
+    Namespace,
+    NamespaceChannel,
+)
 
-__all__ = ["RepoCoreClient", "UPLOAD_TYPE_MAPPING", "API_PATH", "AUTH_API_PATH"]
+__all__ = [
+    "REPO_API_PATH",
+    "AUTH_API_PATH",
+    "RepoCoreClient",
+    "UPLOAD_TYPE_MAPPING",
+    "Channel",
+    "Namespace",
+    "NamespaceChannel",
+]

--- a/binstar_client/repocore/__init__.py
+++ b/binstar_client/repocore/__init__.py
@@ -1,5 +1,5 @@
 """Repocore API client for Anaconda repository channel management."""
 
-from binstar_client.repocore.client import RepoCoreClient, UPLOAD_TYPE_MAPPING, API_PATH
+from binstar_client.repocore.client import RepoCoreClient, UPLOAD_TYPE_MAPPING, API_PATH, AUTH_API_PATH
 
-__all__ = ["RepoCoreClient", "UPLOAD_TYPE_MAPPING", "API_PATH"]
+__all__ = ["RepoCoreClient", "UPLOAD_TYPE_MAPPING", "API_PATH", "AUTH_API_PATH"]

--- a/binstar_client/repocore/__init__.py
+++ b/binstar_client/repocore/__init__.py
@@ -5,6 +5,7 @@ from binstar_client.repocore.models import (
     Channel,
     Namespace,
     NamespaceChannel,
+    ResolvedChannel,
 )
 
 __all__ = [
@@ -15,4 +16,5 @@ __all__ = [
     "Channel",
     "Namespace",
     "NamespaceChannel",
+    "ResolvedChannel",
 ]

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -169,9 +169,7 @@ class RepoCoreClient(BaseClient):
         data = self._manage_response(response, f"getting channel {channel} subchannels")
         return [Channel(**item) for item in data.get("items", [])]
 
-    def create_namespace_channel(
-        self, channel_name: str, namespace: Optional[str] = None, private: bool = True
-    ):
+    def create_namespace_channel(self, channel_name: str, namespace: Optional[str] = None, private: bool = True):
         url = join(self._api_base, "namespace-channels")
         data = {"channel_name": channel_name, "private": private}
 

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -169,9 +169,9 @@ class RepoCoreClient(BaseClient):
         data = self._manage_response(response, f"getting channel {channel} subchannels")
         return [Channel(**item) for item in data.get("items", [])]
 
-    def create_namespace_channel(self, channel_name: str, namespace: Optional[str] = None, private: str = "private"):
+    def create_namespace_channel(self, channel_name: str, namespace: Optional[str] = None, privacy: str = "private"):
         url = join(self._api_base, "namespace-channels")
-        data = {"channel_name": channel_name, "private": private}
+        data = {"channel_name": channel_name, "privacy": privacy}
 
         if namespace:
             data["namespace"] = namespace

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -169,7 +169,7 @@ class RepoCoreClient(BaseClient):
         data = self._manage_response(response, f"getting channel {channel} subchannels")
         return [Channel(**item) for item in data.get("items", [])]
 
-    def create_namespace_channel(self, channel_name: str, namespace: Optional[str] = None, private: bool = True):
+    def create_namespace_channel(self, channel_name: str, namespace: Optional[str] = None, private: str = "private"):
         url = join(self._api_base, "namespace-channels")
         data = {"channel_name": channel_name, "private": private}
 

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -170,10 +170,10 @@ class RepoCoreClient(BaseClient):
         return [Channel(**item) for item in data.get("items", [])]
 
     def create_namespace_channel(
-        self, channel_name: str, namespace: Optional[str] = None, privacy: str = "private"
+        self, channel_name: str, namespace: Optional[str] = None, private: bool = True
     ):
         url = join(self._api_base, "namespace-channels")
-        data = {"channel_name": channel_name, "privacy": privacy}  # TODO: needs confirmation
+        data = {"channel_name": channel_name, "private": private}
 
         if namespace:
             data["namespace"] = namespace

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -164,6 +164,8 @@ class RepoCoreClient(BaseClient):
     def create_namespace_channel(self, subchannel_name: str, namespace: Optional[str] = None, privacy: str = "private"):
         url = join(self._api_base, "namespace-channels")
         data = {"subchannel_name": subchannel_name, "privacy": privacy}
+        # print(f"Namespace: {namespace}\nChannel: {subchannel_name}")
+        # data = {"namespace": namespace, "channel_name": subchannel_name}
         if namespace:
             data["namespace"] = namespace
         response = self.post(url, json=data)

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -20,6 +20,7 @@ UPLOAD_TYPE_MAPPING = {
 logger = logging.getLogger(__name__)
 
 API_PATH = "/api/repo"
+AUTH_API_PATH = "/api/auth"
 
 
 class RepoCoreClient(BaseClient):
@@ -44,6 +45,10 @@ class RepoCoreClient(BaseClient):
     @property
     def _api_base(self):
         return self._base_uri + API_PATH
+
+    @property
+    def _auth_api_base(self):
+        return self._base_uri + AUTH_API_PATH
 
     @property
     def _channels_url(self):
@@ -104,10 +109,10 @@ class RepoCoreClient(BaseClient):
 
         raise RepoCoreError(msg)
 
-    def list_user_channels(self, offset: int = 0, limit: int = 50):
-        url = join(self._api_base, "account", "channels")
-        response = self.get(url, params={"offset": offset, "limit": limit})
-        return self._manage_response(response, "getting user channels")
+    def list_user_organizations(self):
+        url = join(self._auth_api_base, "organizations", "my")
+        response = self.get(url)
+        return self._manage_response(response, "getting user organizations")
 
     def create_channel(self, channel: str, privacy: Optional[str] = None):
         self._validate_channel_name(channel)

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -10,6 +10,11 @@ from typing import Optional
 from anaconda_auth.client import BaseClient
 
 from binstar_client.repocore.errors import InvalidName, LoginRequiredError, RepoCoreError, Unauthorized
+from binstar_client.repocore.models import (
+    Channel,
+    Namespace,
+    NamespaceChannel,
+)
 
 UPLOAD_TYPE_MAPPING = {
     "conda": "conda1",
@@ -19,7 +24,7 @@ UPLOAD_TYPE_MAPPING = {
 
 logger = logging.getLogger(__name__)
 
-API_PATH = "/api/repo"
+REPO_API_PATH = "/api/repo"
 AUTH_API_PATH = "/api/auth"
 
 
@@ -44,7 +49,7 @@ class RepoCoreClient(BaseClient):
 
     @property
     def _api_base(self):
-        return self._base_uri + API_PATH
+        return self._base_uri + REPO_API_PATH
 
     @property
     def _auth_api_base(self):
@@ -109,10 +114,11 @@ class RepoCoreClient(BaseClient):
 
         raise RepoCoreError(msg)
 
-    def list_user_organizations(self):
+    def list_user_organizations(self) -> list[Namespace]:
         url = join(self._auth_api_base, "organizations", "my")
         response = self.get(url)
-        return self._manage_response(response, "getting user organizations")
+        data = self._manage_response(response, "getting user organizations")
+        return [Namespace(**org) for org in data]
 
     def create_channel(self, channel: str, privacy: Optional[str] = None):
         self._validate_channel_name(channel)
@@ -141,10 +147,11 @@ class RepoCoreClient(BaseClient):
             raise Unauthorized(msg)
         raise RepoCoreError(msg)
 
-    def get_channel(self, channel: str):
+    def get_channel(self, channel: str) -> NamespaceChannel:
         url = self._get_channel_url(channel)
         response = self.get(url)
-        return self._manage_response(response, f"getting channel {channel}")
+        data = self._manage_response(response, f"getting channel {channel}")
+        return NamespaceChannel(**data)
 
     def update_channel(self, channel: str, **data):
         url = self._get_channel_url(channel)
@@ -156,21 +163,23 @@ class RepoCoreClient(BaseClient):
             raise Unauthorized(msg)
         raise RepoCoreError(msg)
 
-    def get_channel_subchannels(self, channel: str, offset: int = 0, limit: int = 50):
+    def get_channel_subchannels(self, channel: str, offset: int = 0, limit: int = 50) -> list[Channel]:
         url = join(self._channels_url, channel, "subchannels")
         response = self.get(url, params={"offset": offset, "limit": limit})
-        return self._manage_response(response, f"getting channel {channel} subchannels")
+        data = self._manage_response(response, f"getting channel {channel} subchannels")
+        return [Channel(**item) for item in data.get("items", [])]
 
-    def create_namespace_channel(self, subchannel_name: str, namespace: Optional[str] = None, privacy: str = "private"):
+    def create_namespace_channel(
+        self, channel_name: str, namespace: Optional[str] = None, privacy: str = "private"
+    ):
         url = join(self._api_base, "namespace-channels")
-        data = {"subchannel_name": subchannel_name, "privacy": privacy}
-        # print(f"Namespace: {namespace}\nChannel: {subchannel_name}")
-        # data = {"namespace": namespace, "channel_name": subchannel_name}
+        data = {"channel_name": channel_name, "privacy": privacy}  # TODO: needs confirmation
+
         if namespace:
             data["namespace"] = namespace
         response = self.post(url, json=data)
         return self._manage_response(
-            response, f"creating namespace channel {subchannel_name}", success_codes=[200, 201]
+            response, f"creating namespace channel {channel_name}", success_codes=[200, 201]
         )
 
     def upload_file(self, filepath: str, channel: str, package_type: str, name=None, version=None):

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -169,18 +169,14 @@ class RepoCoreClient(BaseClient):
         data = self._manage_response(response, f"getting channel {channel} subchannels")
         return [Channel(**item) for item in data.get("items", [])]
 
-    def create_namespace_channel(
-        self, channel_name: str, namespace: Optional[str] = None, privacy: str = "private"
-    ):
+    def create_namespace_channel(self, channel_name: str, namespace: Optional[str] = None, privacy: str = "private"):
         url = join(self._api_base, "namespace-channels")
         data = {"channel_name": channel_name, "privacy": privacy}  # TODO: needs confirmation
 
         if namespace:
             data["namespace"] = namespace
         response = self.post(url, json=data)
-        return self._manage_response(
-            response, f"creating namespace channel {channel_name}", success_codes=[200, 201]
-        )
+        return self._manage_response(response, f"creating namespace channel {channel_name}", success_codes=[200, 201])
 
     def upload_file(self, filepath: str, channel: str, package_type: str, name=None, version=None):
         if package_type not in UPLOAD_TYPE_MAPPING:

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -147,7 +147,7 @@ class RepoCoreClient(BaseClient):
             raise Unauthorized(msg)
         raise RepoCoreError(msg)
 
-    def get_channel(self, channel: str) -> NamespaceChannel:
+    def get_namespace_channel(self, channel: str) -> NamespaceChannel:
         url = self._get_channel_url(channel)
         response = self.get(url)
         data = self._manage_response(response, f"getting channel {channel}")
@@ -163,7 +163,7 @@ class RepoCoreClient(BaseClient):
             raise Unauthorized(msg)
         raise RepoCoreError(msg)
 
-    def get_channel_subchannels(self, channel: str, offset: int = 0, limit: int = 50) -> list[Channel]:
+    def get_channels(self, channel: str, offset: int = 0, limit: int = 50) -> list[Channel]:
         url = join(self._channels_url, channel, "subchannels")
         response = self.get(url, params={"offset": offset, "limit": limit})
         data = self._manage_response(response, f"getting channel {channel} subchannels")

--- a/binstar_client/repocore/models.py
+++ b/binstar_client/repocore/models.py
@@ -1,0 +1,52 @@
+"""Pydantic models for repocore API responses."""
+
+from typing import Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+def _handle_none_as_empty_string(v):
+    return v if v is not None else ""
+
+
+class Namespace(BaseModel):
+    """Namespace/organization from the auth API."""
+
+    name: str
+
+
+class Channel(BaseModel):
+    """Channel within a parent namespace channel."""
+
+    name: str
+    privacy: str
+    description: str = ""
+    artifact_count: int = 0
+    download_count: int = 0
+
+    _handle_description = field_validator("description", mode="before")(_handle_none_as_empty_string)
+
+
+class NamespaceChannel(BaseModel):
+    """Parent namespace channel data from the repo API."""
+
+    name: str
+    privacy: str
+    description: str = ""
+    artifact_count: int = 0
+    download_count: int = 0
+    mirror_count: int = 0
+    subchannel_count: int = 0
+    indexing_behavior: str = "default"
+    created: str = ""
+    updated: str = ""
+    owners: list[str] = Field(default_factory=list)
+
+    _handle_description = field_validator("description", mode="before")(_handle_none_as_empty_string)
+
+    @field_validator("owners", mode="before")
+    @classmethod
+    def _filter_none_owners(cls, v):
+        if v is None:
+            return []
+        return [o for o in v if o]

--- a/binstar_client/repocore/models.py
+++ b/binstar_client/repocore/models.py
@@ -50,3 +50,10 @@ class NamespaceChannel(BaseModel):
         if v is None:
             return []
         return [o for o in v if o]
+
+
+class ResolvedChannel(BaseModel):
+    """Resolved namespace and channel name."""
+
+    namespace: Optional[str]
+    channel_name: str

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -344,8 +344,32 @@ class TestRepoCoreChannelsCLI:
             {"id": "2", "name": "org-b", "title": "Org B", "role": "member"},
         ]
         mock_api.get_channel_subchannels.side_effect = [
-            {"total_count": 1, "items": [{"name": "dev", "parent": "org-a", "privacy": "private", "description": "", "artifact_count": 3, "download_count": 1}]},
-            {"total_count": 1, "items": [{"name": "staging", "parent": "org-b", "privacy": "public", "description": "Staging", "artifact_count": 7, "download_count": 2}]},
+            {
+                "total_count": 1,
+                "items": [
+                    {
+                        "name": "dev",
+                        "parent": "org-a",
+                        "privacy": "private",
+                        "description": "",
+                        "artifact_count": 3,
+                        "download_count": 1,
+                    }
+                ],
+            },
+            {
+                "total_count": 1,
+                "items": [
+                    {
+                        "name": "staging",
+                        "parent": "org-b",
+                        "privacy": "public",
+                        "description": "Staging",
+                        "artifact_count": 7,
+                        "download_count": 2,
+                    }
+                ],
+            },
         ]
 
         with _patch_repo_api(mock_api):

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -197,11 +197,11 @@ class TestRepoCoreNamespaceChannel:
         mock_response = _mock_response(201, {"channel_path": "myns/dev"})
         client.post = MagicMock(return_value=mock_response)
 
-        result = client.create_namespace_channel("dev", namespace="myns", privacy="public")
+        result = client.create_namespace_channel("dev", namespace="myns", private=False)
         assert result == {"channel_path": "myns/dev"}
         call_args = client.post.call_args
         assert "namespace-channels" in call_args[0][0]
-        assert call_args[1]["json"] == {"channel_name": "dev", "namespace": "myns", "privacy": "public"}
+        assert call_args[1]["json"] == {"channel_name": "dev", "namespace": "myns", "private": False}
 
     def test_create_namespace_channel_without_namespace(self):
         client = _make_client()
@@ -211,7 +211,7 @@ class TestRepoCoreNamespaceChannel:
         result = client.create_namespace_channel("dev")
         assert result == {"channel_path": "dev/dev"}
         call_args = client.post.call_args
-        assert call_args[1]["json"] == {"channel_name": "dev", "privacy": "private"}
+        assert call_args[1]["json"] == {"channel_name": "dev", "private": True}
 
 
 class TestResolveNamespaceAndChannel:
@@ -389,7 +389,7 @@ class TestRepoCoreChannelsCLI:
         assert result.exit_code == 0
         assert "Success" in result.output
         mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="dev", namespace="myns", privacy="public"
+            channel_name="dev", namespace="myns", private=False
         )
 
     def test_channels_create_with_namespace_flag(self):
@@ -403,7 +403,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="dev", namespace="myns", privacy="public"
+            channel_name="dev", namespace="myns", private=False
         )
 
     def test_channels_create_bare_name_no_namespace_uses_username(self):
@@ -419,7 +419,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="newchannel", namespace="testuser", privacy="private"
+            channel_name="newchannel", namespace="testuser", private=True
         )
 
     def test_channels_create_auto_resolves_namespace(self):
@@ -434,7 +434,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="dev", namespace="myorg", privacy="public"
+            channel_name="dev", namespace="myorg", private=False
         )
 
     def test_channels_create_prompts_for_privacy(self):
@@ -448,7 +448,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="dev", namespace="myns", privacy="public"
+            channel_name="dev", namespace="myns", private=False
         )
 
     def test_channels_create_privacy_prompt_defaults_to_private(self):
@@ -462,7 +462,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="dev", namespace="myns", privacy="private"
+            channel_name="dev", namespace="myns", private=True
         )
 
     def test_channels_create_no_namespaces_no_username(self):
@@ -478,7 +478,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="newchannel", namespace=None, privacy="private"
+            channel_name="newchannel", namespace=None, private=True
         )
 
     def test_channels_create_no_namespaces_with_username(self):
@@ -494,7 +494,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="newchannel", namespace="testuser", privacy="private"
+            channel_name="newchannel", namespace="testuser", private=True
         )
 
     def test_channels_remove_with_namespace_resolution(self):

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -388,7 +388,9 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         assert "Success" in result.output
-        mock_api.create_namespace_channel.assert_called_once_with(channel_name="dev", namespace="myns", private="public")
+        mock_api.create_namespace_channel.assert_called_once_with(
+            channel_name="dev", namespace="myns", private="public"
+        )
 
     def test_channels_create_with_namespace_flag(self):
         runner = CliRunner()
@@ -400,7 +402,9 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["create", "dev", "--namespace", "myns", "--public"])
 
         assert result.exit_code == 0
-        mock_api.create_namespace_channel.assert_called_once_with(channel_name="dev", namespace="myns", private="public")
+        mock_api.create_namespace_channel.assert_called_once_with(
+            channel_name="dev", namespace="myns", private="public"
+        )
 
     def test_channels_create_bare_name_no_namespace_uses_username(self):
         runner = CliRunner()
@@ -429,7 +433,9 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["create", "dev", "--public"])
 
         assert result.exit_code == 0
-        mock_api.create_namespace_channel.assert_called_once_with(channel_name="dev", namespace="myorg", private="public")
+        mock_api.create_namespace_channel.assert_called_once_with(
+            channel_name="dev", namespace="myorg", private="public"
+        )
 
     def test_channels_create_prompts_for_privacy(self):
         runner = CliRunner()
@@ -444,7 +450,9 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["create", "myns/dev"])
 
         assert result.exit_code == 0
-        mock_api.create_namespace_channel.assert_called_once_with(channel_name="dev", namespace="myns", private="public")
+        mock_api.create_namespace_channel.assert_called_once_with(
+            channel_name="dev", namespace="myns", private="public"
+        )
 
     def test_channels_create_privacy_prompt_defaults_to_private(self):
         runner = CliRunner()
@@ -459,7 +467,9 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["create", "myns/dev"])
 
         assert result.exit_code == 0
-        mock_api.create_namespace_channel.assert_called_once_with(channel_name="dev", namespace="myns", private="private")
+        mock_api.create_namespace_channel.assert_called_once_with(
+            channel_name="dev", namespace="myns", private="private"
+        )
 
     def test_channels_create_no_namespaces_no_username(self):
         runner = CliRunner()

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -443,7 +443,10 @@ class TestRepoCoreChannelsCLI:
         mock_api = MagicMock()
         mock_api.create_namespace_channel.return_value = {"channel_path": "myns/dev"}
 
-        with _patch_repo_api(mock_api), patch("binstar_client.commands._repo_channels.select_from_list", return_value="public"):
+        with (
+            _patch_repo_api(mock_api),
+            patch("binstar_client.commands._repo_channels.select_from_list", return_value="public"),
+        ):
             result = runner.invoke(app, ["create", "myns/dev"])
 
         assert result.exit_code == 0
@@ -457,7 +460,10 @@ class TestRepoCoreChannelsCLI:
         mock_api = MagicMock()
         mock_api.create_namespace_channel.return_value = {"channel_path": "myns/dev"}
 
-        with _patch_repo_api(mock_api), patch("binstar_client.commands._repo_channels.select_from_list", return_value="private"):
+        with (
+            _patch_repo_api(mock_api),
+            patch("binstar_client.commands._repo_channels.select_from_list", return_value="private"),
+        ):
             result = runner.invoke(app, ["create", "myns/dev"])
 
         assert result.exit_code == 0

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -123,13 +123,13 @@ class TestRepoCoreClientAPI:
         with pytest.raises(Unauthorized):
             client.remove_channel("my-channel")
 
-    def test_get_channel(self):
+    def test_get_namespace_channel(self):
         client = _make_client()
         channel_data = {"name": "test", "privacy": "public", "artifact_count": 5}
         mock_response = _mock_response(200, channel_data)
         client.get = MagicMock(return_value=mock_response)
 
-        result = client.get_channel("test")
+        result = client.get_namespace_channel("test")
         assert isinstance(result, NamespaceChannel)
         assert result.name == "test"
         assert result.privacy == "public"
@@ -296,7 +296,7 @@ class TestRepoCoreChannelsCLI:
         mock_api.list_user_organizations.return_value = [
             Namespace(name="main"),
         ]
-        mock_api.get_channel_subchannels.return_value = [
+        mock_api.get_channels.return_value = [
             Channel(
                 name="dev",
                 privacy="public",
@@ -346,7 +346,7 @@ class TestRepoCoreChannelsCLI:
             Namespace(name="org-a"),
             Namespace(name="org-b"),
         ]
-        mock_api.get_channel_subchannels.side_effect = [
+        mock_api.get_channels.side_effect = [
             [
                 Channel(
                     name="dev",
@@ -375,7 +375,7 @@ class TestRepoCoreChannelsCLI:
         assert "org-b" in result.output
         assert "dev" in result.output
         assert "staging" in result.output
-        assert mock_api.get_channel_subchannels.call_count == 2
+        assert mock_api.get_channels.call_count == 2
 
     def test_channels_create_with_slash(self):
         runner = CliRunner()
@@ -550,7 +550,7 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["show", "dev", "--namespace", "myorg"])
 
         assert result.exit_code == 0
-        mock_api.get_channel.assert_called_once_with("myorg/dev")
+        mock_api.get_namespace_channel.assert_called_once_with("myorg/dev")
 
     def test_channels_modify_with_namespace_resolution(self):
         runner = CliRunner()

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -387,19 +387,20 @@ class TestRepoCoreChannelsCLI:
             subchannel_name="dev", namespace="myns", privacy="public"
         )
 
-    def test_channels_create_bare_name_no_namespace_delegates_to_api(self):
+    def test_channels_create_bare_name_no_namespace_uses_username(self):
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = []
-        mock_api.create_namespace_channel.return_value = {"channel_path": "newchannel/newchannel"}
+        mock_api.account = {"user": {"username": "testuser"}}
+        mock_api.create_namespace_channel.return_value = {"channel_path": "testuser/newchannel"}
 
         with _patch_repo_api(mock_api):
-            result = runner.invoke(app, ["create", "newchannel"])
+            result = runner.invoke(app, ["create", "newchannel", "--private"], input="y\n")
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            subchannel_name="newchannel", namespace=None, privacy="private"
+            subchannel_name="newchannel", namespace="testuser", privacy="private"
         )
 
     def test_channels_create_auto_resolves_namespace(self):
@@ -415,6 +416,34 @@ class TestRepoCoreChannelsCLI:
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
             subchannel_name="dev", namespace="myorg", privacy="public"
+        )
+
+    def test_channels_create_prompts_for_privacy(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.create_namespace_channel.return_value = {"channel_path": "myns/dev"}
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["create", "myns/dev"], input="2\n")
+
+        assert result.exit_code == 0
+        mock_api.create_namespace_channel.assert_called_once_with(
+            subchannel_name="dev", namespace="myns", privacy="public"
+        )
+
+    def test_channels_create_privacy_prompt_defaults_to_private(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.create_namespace_channel.return_value = {"channel_path": "myns/dev"}
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["create", "myns/dev"], input="\n")
+
+        assert result.exit_code == 0
+        mock_api.create_namespace_channel.assert_called_once_with(
+            subchannel_name="dev", namespace="myns", privacy="private"
         )
 
     def test_channels_remove_with_namespace_resolution(self):

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -470,6 +470,38 @@ class TestRepoCoreChannelsCLI:
             subchannel_name="dev", namespace="myns", privacy="private"
         )
 
+    def test_channels_create_no_namespaces_no_username(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_user_organizations.return_value = []
+        type(mock_api).account = PropertyMock(side_effect=Exception("No account"))
+        mock_api.create_namespace_channel.return_value = {"channel_path": "newchannel"}
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["create", "newchannel", "--private"])
+
+        assert result.exit_code == 0
+        mock_api.create_namespace_channel.assert_called_once_with(
+            subchannel_name="newchannel", namespace=None, privacy="private"
+        )
+
+    def test_channels_create_no_namespaces_with_username(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_user_organizations.return_value = []
+        type(mock_api).account = PropertyMock(return_value={"user": {"username": "testuser"}})
+        mock_api.create_namespace_channel.return_value = {"channel_path": "testuser/newchannel"}
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["create", "newchannel", "--private"], input="y\n")
+
+        assert result.exit_code == 0
+        mock_api.create_namespace_channel.assert_called_once_with(
+            subchannel_name="newchannel", namespace="testuser", privacy="private"
+        )
+
     def test_channels_remove_with_namespace_resolution(self):
         runner = CliRunner()
         app = _get_channels_app()

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -5,7 +5,12 @@ from unittest.mock import MagicMock, PropertyMock, patch
 import pytest
 from typer.testing import CliRunner
 
-from binstar_client.repocore import RepoCoreClient
+from binstar_client.repocore import (
+    Channel,
+    Namespace,
+    NamespaceChannel,
+    RepoCoreClient,
+)
 from binstar_client.repocore.errors import (
     InvalidName,
     LoginRequiredError,
@@ -56,14 +61,17 @@ class TestRepoCoreClientAPI:
     def test_list_user_organizations(self):
         client = _make_client()
         orgs = [
-            {"id": "abc-123", "name": "anaconda-dfw", "title": "Anaconda DogFood Wheels", "role": "admin"},
-            {"id": "def-456", "name": "my-team", "title": "My Team", "role": "member"},
+            {"name": "anaconda-dfw"},
+            {"name": "my-team"},
         ]
         mock_response = _mock_response(200, orgs)
         client.get = MagicMock(return_value=mock_response)
 
         result = client.list_user_organizations()
-        assert result == orgs
+        assert len(result) == 2
+        assert all(isinstance(org, Namespace) for org in result)
+        assert result[0].name == "anaconda-dfw"
+        assert result[1].name == "my-team"
         client.get.assert_called_once()
         call_url = client.get.call_args[0][0]
         assert "/api/auth/organizations/my" in call_url
@@ -75,6 +83,7 @@ class TestRepoCoreClientAPI:
 
         result = client.list_user_organizations()
         assert result == []
+        assert isinstance(result, list)
 
     def test_create_channel(self):
         client = _make_client()
@@ -121,7 +130,10 @@ class TestRepoCoreClientAPI:
         client.get = MagicMock(return_value=mock_response)
 
         result = client.get_channel("test")
-        assert result == channel_data
+        assert isinstance(result, NamespaceChannel)
+        assert result.name == "test"
+        assert result.privacy == "public"
+        assert result.artifact_count == 5
 
     def test_update_channel(self):
         client = _make_client()
@@ -182,28 +194,24 @@ class TestLoginRequiredErrorHandler:
 class TestRepoCoreNamespaceChannel:
     def test_create_namespace_channel(self):
         client = _make_client()
-        mock_response = _mock_response(
-            201, {"org_id": "abc", "namespace": "myns", "channel_name": "dev", "channel_path": "myns/dev"}
-        )
+        mock_response = _mock_response(201, {"channel_path": "myns/dev"})
         client.post = MagicMock(return_value=mock_response)
 
         result = client.create_namespace_channel("dev", namespace="myns", privacy="public")
-        assert result["channel_path"] == "myns/dev"
+        assert result == {"channel_path": "myns/dev"}
         call_args = client.post.call_args
         assert "namespace-channels" in call_args[0][0]
-        assert call_args[1]["json"] == {"subchannel_name": "dev", "namespace": "myns", "privacy": "public"}
+        assert call_args[1]["json"] == {"channel_name": "dev", "namespace": "myns", "privacy": "public"}
 
     def test_create_namespace_channel_without_namespace(self):
         client = _make_client()
-        mock_response = _mock_response(
-            201, {"org_id": "abc", "namespace": "dev", "channel_name": "dev", "channel_path": "dev/dev"}
-        )
+        mock_response = _mock_response(201, {"channel_path": "dev/dev"})
         client.post = MagicMock(return_value=mock_response)
 
         result = client.create_namespace_channel("dev")
-        assert result["channel_path"] == "dev/dev"
+        assert result == {"channel_path": "dev/dev"}
         call_args = client.post.call_args
-        assert call_args[1]["json"] == {"subchannel_name": "dev", "privacy": "private"}
+        assert call_args[1]["json"] == {"channel_name": "dev", "privacy": "private"}
 
 
 class TestResolveNamespaceAndChannel:
@@ -238,7 +246,7 @@ class TestResolveNamespaceAndChannel:
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
 
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [{"name": "myorg"}]
+        mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
         ns, ch = _resolve_namespace_and_channel(mock_api, "dev")
         assert ns == "myorg"
         assert ch == "dev"
@@ -257,9 +265,12 @@ class TestResolveNamespaceAndChannel:
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
 
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [{"name": "org-a"}, {"name": "org-b"}]
+        mock_api.list_user_organizations.return_value = [
+            Namespace(name="org-a"),
+            Namespace(name="org-b"),
+        ]
 
-        with patch("binstar_client.commands._repo_channels.typer.prompt", return_value="2"):
+        with patch("binstar_client.commands._repo_channels.select_from_list", return_value="org-b"):
             ns, ch = _resolve_namespace_and_channel(mock_api, "dev")
 
         assert ns == "org-b"
@@ -283,21 +294,17 @@ class TestRepoCoreChannelsCLI:
         app = _get_channels_app()
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = [
-            {"id": "1", "name": "main", "title": "Main Org", "role": "admin"},
+            Namespace(name="main"),
         ]
-        mock_api.get_channel_subchannels.return_value = {
-            "total_count": 1,
-            "items": [
-                {
-                    "name": "dev",
-                    "parent": "main",
-                    "privacy": "public",
-                    "description": "",
-                    "artifact_count": 10,
-                    "download_count": 5,
-                }
-            ],
-        }
+        mock_api.get_channel_subchannels.return_value = [
+            Channel(
+                name="dev",
+                privacy="public",
+                description="",
+                artifact_count=10,
+                download_count=5,
+            )
+        ]
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["list"])
@@ -311,22 +318,18 @@ class TestRepoCoreChannelsCLI:
         app = _get_channels_app()
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = [
-            {"id": "1", "name": "org-a", "title": "Org A", "role": "admin"},
-            {"id": "2", "name": "org-b", "title": "Org B", "role": "member"},
+            Namespace(name="org-a"),
+            Namespace(name="org-b"),
         ]
-        mock_api.get_channel_subchannels.return_value = {
-            "total_count": 1,
-            "items": [
-                {
-                    "name": "dev",
-                    "parent": "org-a",
-                    "privacy": "public",
-                    "description": "",
-                    "artifact_count": 5,
-                    "download_count": 1,
-                }
-            ],
-        }
+        mock_api.get_channel_subchannels.return_value = [
+            Channel(
+                name="dev",
+                privacy="public",
+                description="",
+                artifact_count=5,
+                download_count=1,
+            )
+        ]
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["list", "--namespace", "org-a"])
@@ -340,36 +343,28 @@ class TestRepoCoreChannelsCLI:
         app = _get_channels_app()
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = [
-            {"id": "1", "name": "org-a", "title": "Org A", "role": "admin"},
-            {"id": "2", "name": "org-b", "title": "Org B", "role": "member"},
+            Namespace(name="org-a"),
+            Namespace(name="org-b"),
         ]
         mock_api.get_channel_subchannels.side_effect = [
-            {
-                "total_count": 1,
-                "items": [
-                    {
-                        "name": "dev",
-                        "parent": "org-a",
-                        "privacy": "private",
-                        "description": "",
-                        "artifact_count": 3,
-                        "download_count": 1,
-                    }
-                ],
-            },
-            {
-                "total_count": 1,
-                "items": [
-                    {
-                        "name": "staging",
-                        "parent": "org-b",
-                        "privacy": "public",
-                        "description": "Staging",
-                        "artifact_count": 7,
-                        "download_count": 2,
-                    }
-                ],
-            },
+            [
+                Channel(
+                    name="dev",
+                    privacy="private",
+                    description="",
+                    artifact_count=3,
+                    download_count=1,
+                )
+            ],
+            [
+                Channel(
+                    name="staging",
+                    privacy="public",
+                    description="Staging",
+                    artifact_count=7,
+                    download_count=2,
+                )
+            ],
         ]
 
         with _patch_repo_api(mock_api):
@@ -394,7 +389,7 @@ class TestRepoCoreChannelsCLI:
         assert result.exit_code == 0
         assert "Success" in result.output
         mock_api.create_namespace_channel.assert_called_once_with(
-            subchannel_name="dev", namespace="myns", privacy="public"
+            channel_name="dev", namespace="myns", privacy="public"
         )
 
     def test_channels_create_with_namespace_flag(self):
@@ -408,7 +403,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            subchannel_name="dev", namespace="myns", privacy="public"
+            channel_name="dev", namespace="myns", privacy="public"
         )
 
     def test_channels_create_bare_name_no_namespace_uses_username(self):
@@ -424,14 +419,14 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            subchannel_name="newchannel", namespace="testuser", privacy="private"
+            channel_name="newchannel", namespace="testuser", privacy="private"
         )
 
     def test_channels_create_auto_resolves_namespace(self):
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [{"name": "myorg"}]
+        mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
         mock_api.create_namespace_channel.return_value = {"channel_path": "myorg/dev"}
 
         with _patch_repo_api(mock_api):
@@ -439,7 +434,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            subchannel_name="dev", namespace="myorg", privacy="public"
+            channel_name="dev", namespace="myorg", privacy="public"
         )
 
     def test_channels_create_prompts_for_privacy(self):
@@ -448,12 +443,12 @@ class TestRepoCoreChannelsCLI:
         mock_api = MagicMock()
         mock_api.create_namespace_channel.return_value = {"channel_path": "myns/dev"}
 
-        with _patch_repo_api(mock_api):
-            result = runner.invoke(app, ["create", "myns/dev"], input="2\n")
+        with _patch_repo_api(mock_api), patch("binstar_client.commands._repo_channels.select_from_list", return_value="public"):
+            result = runner.invoke(app, ["create", "myns/dev"])
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            subchannel_name="dev", namespace="myns", privacy="public"
+            channel_name="dev", namespace="myns", privacy="public"
         )
 
     def test_channels_create_privacy_prompt_defaults_to_private(self):
@@ -462,12 +457,12 @@ class TestRepoCoreChannelsCLI:
         mock_api = MagicMock()
         mock_api.create_namespace_channel.return_value = {"channel_path": "myns/dev"}
 
-        with _patch_repo_api(mock_api):
-            result = runner.invoke(app, ["create", "myns/dev"], input="\n")
+        with _patch_repo_api(mock_api), patch("binstar_client.commands._repo_channels.select_from_list", return_value="private"):
+            result = runner.invoke(app, ["create", "myns/dev"])
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            subchannel_name="dev", namespace="myns", privacy="private"
+            channel_name="dev", namespace="myns", privacy="private"
         )
 
     def test_channels_create_no_namespaces_no_username(self):
@@ -483,7 +478,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            subchannel_name="newchannel", namespace=None, privacy="private"
+            channel_name="newchannel", namespace=None, privacy="private"
         )
 
     def test_channels_create_no_namespaces_with_username(self):
@@ -499,14 +494,14 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            subchannel_name="newchannel", namespace="testuser", privacy="private"
+            channel_name="newchannel", namespace="testuser", privacy="private"
         )
 
     def test_channels_remove_with_namespace_resolution(self):
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [{"name": "myorg"}]
+        mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["remove", "dev"])
@@ -541,18 +536,18 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.get_channel.return_value = {
-            "name": "dev",
-            "privacy": "private",
-            "description": "",
-            "artifact_count": 0,
-            "download_count": 0,
-            "mirror_count": 0,
-            "subchannel_count": 0,
-            "indexing_behavior": "default",
-            "created": "2025-01-01",
-            "updated": "2025-06-01",
-        }
+        mock_api.get_channel.return_value = NamespaceChannel(
+            name="dev",
+            privacy="private",
+            description="",
+            artifact_count=0,
+            download_count=0,
+            mirror_count=0,
+            subchannel_count=0,
+            indexing_behavior="default",
+            created="2025-01-01",
+            updated="2025-06-01",
+        )
         mock_api.is_subchannel.return_value = True
 
         with _patch_repo_api(mock_api):
@@ -565,7 +560,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [{"name": "myorg"}]
+        mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["modify", "dev", "--privacy", "private"])

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -197,11 +197,11 @@ class TestRepoCoreNamespaceChannel:
         mock_response = _mock_response(201, {"channel_path": "myns/dev"})
         client.post = MagicMock(return_value=mock_response)
 
-        result = client.create_namespace_channel("dev", namespace="myns", private=False)
+        result = client.create_namespace_channel("dev", namespace="myns", private="public")
         assert result == {"channel_path": "myns/dev"}
         call_args = client.post.call_args
         assert "namespace-channels" in call_args[0][0]
-        assert call_args[1]["json"] == {"channel_name": "dev", "namespace": "myns", "private": False}
+        assert call_args[1]["json"] == {"channel_name": "dev", "namespace": "myns", "private": "public"}
 
     def test_create_namespace_channel_without_namespace(self):
         client = _make_client()
@@ -211,7 +211,7 @@ class TestRepoCoreNamespaceChannel:
         result = client.create_namespace_channel("dev")
         assert result == {"channel_path": "dev/dev"}
         call_args = client.post.call_args
-        assert call_args[1]["json"] == {"channel_name": "dev", "private": True}
+        assert call_args[1]["json"] == {"channel_name": "dev", "private": "private"}
 
 
 class TestResolveNamespaceAndChannel:
@@ -388,7 +388,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         assert "Success" in result.output
-        mock_api.create_namespace_channel.assert_called_once_with(channel_name="dev", namespace="myns", private=False)
+        mock_api.create_namespace_channel.assert_called_once_with(channel_name="dev", namespace="myns", private="public")
 
     def test_channels_create_with_namespace_flag(self):
         runner = CliRunner()
@@ -400,7 +400,7 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["create", "dev", "--namespace", "myns", "--public"])
 
         assert result.exit_code == 0
-        mock_api.create_namespace_channel.assert_called_once_with(channel_name="dev", namespace="myns", private=False)
+        mock_api.create_namespace_channel.assert_called_once_with(channel_name="dev", namespace="myns", private="public")
 
     def test_channels_create_bare_name_no_namespace_uses_username(self):
         runner = CliRunner()
@@ -415,7 +415,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="newchannel", namespace="testuser", private=True
+            channel_name="newchannel", namespace="testuser", private="private"
         )
 
     def test_channels_create_auto_resolves_namespace(self):
@@ -429,7 +429,7 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["create", "dev", "--public"])
 
         assert result.exit_code == 0
-        mock_api.create_namespace_channel.assert_called_once_with(channel_name="dev", namespace="myorg", private=False)
+        mock_api.create_namespace_channel.assert_called_once_with(channel_name="dev", namespace="myorg", private="public")
 
     def test_channels_create_prompts_for_privacy(self):
         runner = CliRunner()
@@ -444,7 +444,7 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["create", "myns/dev"])
 
         assert result.exit_code == 0
-        mock_api.create_namespace_channel.assert_called_once_with(channel_name="dev", namespace="myns", private=False)
+        mock_api.create_namespace_channel.assert_called_once_with(channel_name="dev", namespace="myns", private="public")
 
     def test_channels_create_privacy_prompt_defaults_to_private(self):
         runner = CliRunner()
@@ -459,7 +459,7 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["create", "myns/dev"])
 
         assert result.exit_code == 0
-        mock_api.create_namespace_channel.assert_called_once_with(channel_name="dev", namespace="myns", private=True)
+        mock_api.create_namespace_channel.assert_called_once_with(channel_name="dev", namespace="myns", private="private")
 
     def test_channels_create_no_namespaces_no_username(self):
         runner = CliRunner()
@@ -474,7 +474,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="newchannel", namespace=None, private=True
+            channel_name="newchannel", namespace=None, private="private"
         )
 
     def test_channels_create_no_namespaces_with_username(self):
@@ -490,7 +490,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="newchannel", namespace="testuser", private=True
+            channel_name="newchannel", namespace="testuser", private="private"
         )
 
     def test_channels_remove_with_namespace_resolution(self):

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -53,16 +53,28 @@ class TestRepoCoreClientValidation:
 
 
 class TestRepoCoreClientAPI:
-    def test_list_user_channels(self):
+    def test_list_user_organizations(self):
         client = _make_client()
-        mock_response = _mock_response(200, {"items": [{"name": "test"}]})
+        orgs = [
+            {"id": "abc-123", "name": "anaconda-dfw", "title": "Anaconda DogFood Wheels", "role": "admin"},
+            {"id": "def-456", "name": "my-team", "title": "My Team", "role": "member"},
+        ]
+        mock_response = _mock_response(200, orgs)
         client.get = MagicMock(return_value=mock_response)
 
-        result = client.list_user_channels(offset=0, limit=10)
-        assert result == {"items": [{"name": "test"}]}
+        result = client.list_user_organizations()
+        assert result == orgs
         client.get.assert_called_once()
-        call_kwargs = client.get.call_args
-        assert "offset" in str(call_kwargs)
+        call_url = client.get.call_args[0][0]
+        assert "/api/auth/organizations/my" in call_url
+
+    def test_list_user_organizations_empty(self):
+        client = _make_client()
+        mock_response = _mock_response(200, [])
+        client.get = MagicMock(return_value=mock_response)
+
+        result = client.list_user_organizations()
+        assert result == []
 
     def test_create_channel(self):
         client = _make_client()
@@ -202,7 +214,7 @@ class TestResolveNamespaceAndChannel:
         ns, ch = _resolve_namespace_and_channel(mock_api, "myorg/dev")
         assert ns == "myorg"
         assert ch == "dev"
-        mock_api.list_user_channels.assert_not_called()
+        mock_api.list_user_organizations.assert_not_called()
 
     def test_explicit_namespace_flag(self):
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
@@ -211,7 +223,7 @@ class TestResolveNamespaceAndChannel:
         ns, ch = _resolve_namespace_and_channel(mock_api, "dev", namespace="myorg")
         assert ns == "myorg"
         assert ch == "dev"
-        mock_api.list_user_channels.assert_not_called()
+        mock_api.list_user_organizations.assert_not_called()
 
     def test_ambiguous_slash_and_flag_exits(self):
         from click.exceptions import Exit
@@ -226,7 +238,7 @@ class TestResolveNamespaceAndChannel:
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
 
         mock_api = MagicMock()
-        mock_api.list_user_channels.return_value = {"items": [{"name": "myorg"}]}
+        mock_api.list_user_organizations.return_value = [{"name": "myorg"}]
         ns, ch = _resolve_namespace_and_channel(mock_api, "dev")
         assert ns == "myorg"
         assert ch == "dev"
@@ -237,7 +249,7 @@ class TestResolveNamespaceAndChannel:
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
 
         mock_api = MagicMock()
-        mock_api.list_user_channels.return_value = {"items": []}
+        mock_api.list_user_organizations.return_value = []
         with pytest.raises(Exit):
             _resolve_namespace_and_channel(mock_api, "dev")
 
@@ -245,7 +257,7 @@ class TestResolveNamespaceAndChannel:
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
 
         mock_api = MagicMock()
-        mock_api.list_user_channels.return_value = {"items": [{"name": "org-a"}, {"name": "org-b"}]}
+        mock_api.list_user_organizations.return_value = [{"name": "org-a"}, {"name": "org-b"}]
 
         with patch("binstar_client.commands._repo_channels.typer.prompt", return_value="2"):
             ns, ch = _resolve_namespace_and_channel(mock_api, "dev")
@@ -270,17 +282,21 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_channels.return_value = {
+        mock_api.list_user_organizations.return_value = [
+            {"id": "1", "name": "main", "title": "Main Org", "role": "admin"},
+        ]
+        mock_api.get_channel_subchannels.return_value = {
+            "total_count": 1,
             "items": [
                 {
-                    "name": "main",
+                    "name": "dev",
+                    "parent": "main",
                     "privacy": "public",
                     "description": "",
                     "artifact_count": 10,
                     "download_count": 5,
-                    "subchannel_count": 0,
                 }
-            ]
+            ],
         }
 
         with _patch_repo_api(mock_api):
@@ -288,30 +304,28 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         assert "main" in result.output
+        assert "dev" in result.output
 
     def test_channels_list_with_namespace_filter(self):
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_channels.return_value = {
+        mock_api.list_user_organizations.return_value = [
+            {"id": "1", "name": "org-a", "title": "Org A", "role": "admin"},
+            {"id": "2", "name": "org-b", "title": "Org B", "role": "member"},
+        ]
+        mock_api.get_channel_subchannels.return_value = {
+            "total_count": 1,
             "items": [
                 {
-                    "name": "org-a",
+                    "name": "dev",
+                    "parent": "org-a",
                     "privacy": "public",
                     "description": "",
                     "artifact_count": 5,
                     "download_count": 1,
-                    "subchannel_count": 0,
-                },
-                {
-                    "name": "org-b",
-                    "privacy": "private",
-                    "description": "",
-                    "artifact_count": 3,
-                    "download_count": 0,
-                    "subchannel_count": 0,
-                },
-            ]
+                }
+            ],
         }
 
         with _patch_repo_api(mock_api):
@@ -320,6 +334,29 @@ class TestRepoCoreChannelsCLI:
         assert result.exit_code == 0
         assert "org-a" in result.output
         assert "org-b" not in result.output
+
+    def test_channels_list_fetches_subchannels_per_org(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_user_organizations.return_value = [
+            {"id": "1", "name": "org-a", "title": "Org A", "role": "admin"},
+            {"id": "2", "name": "org-b", "title": "Org B", "role": "member"},
+        ]
+        mock_api.get_channel_subchannels.side_effect = [
+            {"total_count": 1, "items": [{"name": "dev", "parent": "org-a", "privacy": "private", "description": "", "artifact_count": 3, "download_count": 1}]},
+            {"total_count": 1, "items": [{"name": "staging", "parent": "org-b", "privacy": "public", "description": "Staging", "artifact_count": 7, "download_count": 2}]},
+        ]
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["list"])
+
+        assert result.exit_code == 0
+        assert "org-a" in result.output
+        assert "org-b" in result.output
+        assert "dev" in result.output
+        assert "staging" in result.output
+        assert mock_api.get_channel_subchannels.call_count == 2
 
     def test_channels_create_with_slash(self):
         runner = CliRunner()
@@ -354,7 +391,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_channels.return_value = {"items": []}
+        mock_api.list_user_organizations.return_value = []
         mock_api.create_namespace_channel.return_value = {"channel_path": "newchannel/newchannel"}
 
         with _patch_repo_api(mock_api):
@@ -369,7 +406,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_channels.return_value = {"items": [{"name": "myorg"}]}
+        mock_api.list_user_organizations.return_value = [{"name": "myorg"}]
         mock_api.create_namespace_channel.return_value = {"channel_path": "myorg/dev"}
 
         with _patch_repo_api(mock_api):
@@ -384,7 +421,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_channels.return_value = {"items": [{"name": "myorg"}]}
+        mock_api.list_user_organizations.return_value = [{"name": "myorg"}]
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["remove", "dev"])
@@ -407,7 +444,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_channels.return_value = {"items": []}
+        mock_api.list_user_organizations.return_value = []
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["remove", "dev"])
@@ -443,7 +480,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_channels.return_value = {"items": [{"name": "myorg"}]}
+        mock_api.list_user_organizations.return_value = [{"name": "myorg"}]
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["modify", "dev", "--privacy", "private"])

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -388,9 +388,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         assert "Success" in result.output
-        mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="dev", namespace="myns", private=False
-        )
+        mock_api.create_namespace_channel.assert_called_once_with(channel_name="dev", namespace="myns", private=False)
 
     def test_channels_create_with_namespace_flag(self):
         runner = CliRunner()
@@ -402,9 +400,7 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["create", "dev", "--namespace", "myns", "--public"])
 
         assert result.exit_code == 0
-        mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="dev", namespace="myns", private=False
-        )
+        mock_api.create_namespace_channel.assert_called_once_with(channel_name="dev", namespace="myns", private=False)
 
     def test_channels_create_bare_name_no_namespace_uses_username(self):
         runner = CliRunner()
@@ -433,9 +429,7 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["create", "dev", "--public"])
 
         assert result.exit_code == 0
-        mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="dev", namespace="myorg", private=False
-        )
+        mock_api.create_namespace_channel.assert_called_once_with(channel_name="dev", namespace="myorg", private=False)
 
     def test_channels_create_prompts_for_privacy(self):
         runner = CliRunner()
@@ -450,9 +444,7 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["create", "myns/dev"])
 
         assert result.exit_code == 0
-        mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="dev", namespace="myns", private=False
-        )
+        mock_api.create_namespace_channel.assert_called_once_with(channel_name="dev", namespace="myns", private=False)
 
     def test_channels_create_privacy_prompt_defaults_to_private(self):
         runner = CliRunner()
@@ -467,9 +459,7 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["create", "myns/dev"])
 
         assert result.exit_code == 0
-        mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="dev", namespace="myns", private=True
-        )
+        mock_api.create_namespace_channel.assert_called_once_with(channel_name="dev", namespace="myns", private=True)
 
     def test_channels_create_no_namespaces_no_username(self):
         runner = CliRunner()

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -197,11 +197,11 @@ class TestRepoCoreNamespaceChannel:
         mock_response = _mock_response(201, {"channel_path": "myns/dev"})
         client.post = MagicMock(return_value=mock_response)
 
-        result = client.create_namespace_channel("dev", namespace="myns", private="public")
+        result = client.create_namespace_channel("dev", namespace="myns", privacy="public")
         assert result == {"channel_path": "myns/dev"}
         call_args = client.post.call_args
         assert "namespace-channels" in call_args[0][0]
-        assert call_args[1]["json"] == {"channel_name": "dev", "namespace": "myns", "private": "public"}
+        assert call_args[1]["json"] == {"channel_name": "dev", "namespace": "myns", "privacy": "public"}
 
     def test_create_namespace_channel_without_namespace(self):
         client = _make_client()
@@ -211,7 +211,7 @@ class TestRepoCoreNamespaceChannel:
         result = client.create_namespace_channel("dev")
         assert result == {"channel_path": "dev/dev"}
         call_args = client.post.call_args
-        assert call_args[1]["json"] == {"channel_name": "dev", "private": "private"}
+        assert call_args[1]["json"] == {"channel_name": "dev", "privacy": "private"}
 
 
 class TestResolveNamespaceAndChannel:
@@ -389,7 +389,7 @@ class TestRepoCoreChannelsCLI:
         assert result.exit_code == 0
         assert "Success" in result.output
         mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="dev", namespace="myns", private="public"
+            channel_name="dev", namespace="myns", privacy="public"
         )
 
     def test_channels_create_with_namespace_flag(self):
@@ -403,7 +403,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="dev", namespace="myns", private="public"
+            channel_name="dev", namespace="myns", privacy="public"
         )
 
     def test_channels_create_bare_name_no_namespace_uses_username(self):
@@ -419,7 +419,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="newchannel", namespace="testuser", private="private"
+            channel_name="newchannel", namespace="testuser", privacy="private"
         )
 
     def test_channels_create_auto_resolves_namespace(self):
@@ -434,7 +434,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="dev", namespace="myorg", private="public"
+            channel_name="dev", namespace="myorg", privacy="public"
         )
 
     def test_channels_create_prompts_for_privacy(self):
@@ -451,7 +451,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="dev", namespace="myns", private="public"
+            channel_name="dev", namespace="myns", privacy="public"
         )
 
     def test_channels_create_privacy_prompt_defaults_to_private(self):
@@ -468,7 +468,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="dev", namespace="myns", private="private"
+            channel_name="dev", namespace="myns", privacy="private"
         )
 
     def test_channels_create_no_namespaces_no_username(self):
@@ -484,7 +484,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="newchannel", namespace=None, private="private"
+            channel_name="newchannel", namespace=None, privacy="private"
         )
 
     def test_channels_create_no_namespaces_with_username(self):
@@ -500,7 +500,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="newchannel", namespace="testuser", private="private"
+            channel_name="newchannel", namespace="testuser", privacy="private"
         )
 
     def test_channels_remove_with_namespace_resolution(self):

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -10,6 +10,7 @@ from binstar_client.repocore import (
     Namespace,
     NamespaceChannel,
     RepoCoreClient,
+    ResolvedChannel,
 )
 from binstar_client.repocore.errors import (
     InvalidName,
@@ -17,6 +18,67 @@ from binstar_client.repocore.errors import (
     RepoCoreError,
     Unauthorized,
 )
+
+
+class TestPydanticModels:
+    def test_namespace_model(self):
+        ns = Namespace(name="test-org")
+        assert ns.name == "test-org"
+        assert isinstance(ns, Namespace)
+
+    def test_channel_model(self):
+        ch = Channel(name="dev", privacy="private", description=None)
+        assert ch.name == "dev"
+        assert ch.privacy == "private"
+        assert ch.description == ""
+        assert ch.artifact_count == 0
+
+    def test_namespace_channel_model(self):
+        nsch = NamespaceChannel(name="myorg/dev", privacy="private", owners=["user1", None, "user2"])
+        assert nsch.name == "myorg/dev"
+        assert nsch.owners == ["user1", "user2"]
+        assert nsch.indexing_behavior == "default"
+
+    def test_resolved_channel_model(self):
+        resolved = ResolvedChannel(namespace="myorg", channel_name="dev")
+        assert resolved.namespace == "myorg"
+        assert resolved.channel_name == "dev"
+
+    def test_namespace_model_used_in_list_organizations(self):
+        client = _make_client()
+        orgs = [{"name": "org1"}, {"name": "org2"}]
+        mock_response = _mock_response(200, orgs)
+        client.get = MagicMock(return_value=mock_response)
+        result = client.list_user_organizations()
+        assert all(isinstance(org, Namespace) for org in result)
+        assert result[0].name == "org1"
+
+    def test_channel_model_used_in_get_channels(self):
+        client = _make_client()
+        channels = {"items": [{"name": "dev", "privacy": "private", "artifact_count": 5, "download_count": 10}]}
+        mock_response = _mock_response(200, channels)
+        client.get = MagicMock(return_value=mock_response)
+        result = client.get_channels("myorg")
+        assert all(isinstance(ch, Channel) for ch in result)
+        assert result[0].name == "dev"
+
+    def test_namespace_channel_model_used_in_get_namespace_channel(self):
+        client = _make_client()
+        channel = {"name": "myorg/dev", "privacy": "private", "owners": ["user1"]}
+        mock_response = _mock_response(200, channel)
+        client.get = MagicMock(return_value=mock_response)
+        result = client.get_namespace_channel("myorg/dev")
+        assert isinstance(result, NamespaceChannel)
+        assert result.name == "myorg/dev"
+
+    def test_resolved_channel_model_used_in_resolve_namespace_and_channel(self):
+        from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
+
+        mock_api = MagicMock()
+        result = _resolve_namespace_and_channel(mock_api, "myorg/dev")
+        assert isinstance(result, ResolvedChannel)
+        assert result.namespace == "myorg"
+        assert result.channel_name == "dev"
 
 
 class TestRepoCoreClientValidation:
@@ -219,18 +281,18 @@ class TestResolveNamespaceAndChannel:
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
 
         mock_api = MagicMock()
-        ns, ch = _resolve_namespace_and_channel(mock_api, "myorg/dev")
-        assert ns == "myorg"
-        assert ch == "dev"
+        resolved = _resolve_namespace_and_channel(mock_api, "myorg/dev")
+        assert resolved.namespace == "myorg"
+        assert resolved.channel_name == "dev"
         mock_api.list_user_organizations.assert_not_called()
 
     def test_explicit_namespace_flag(self):
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
 
         mock_api = MagicMock()
-        ns, ch = _resolve_namespace_and_channel(mock_api, "dev", namespace="myorg")
-        assert ns == "myorg"
-        assert ch == "dev"
+        resolved = _resolve_namespace_and_channel(mock_api, "dev", namespace="myorg")
+        assert resolved.namespace == "myorg"
+        assert resolved.channel_name == "dev"
         mock_api.list_user_organizations.assert_not_called()
 
     def test_ambiguous_slash_and_flag_exits(self):
@@ -247,9 +309,9 @@ class TestResolveNamespaceAndChannel:
 
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
-        ns, ch = _resolve_namespace_and_channel(mock_api, "dev")
-        assert ns == "myorg"
-        assert ch == "dev"
+        resolved = _resolve_namespace_and_channel(mock_api, "dev")
+        assert resolved.namespace == "myorg"
+        assert resolved.channel_name == "dev"
 
     def test_no_namespaces_exits(self):
         from click.exceptions import Exit
@@ -271,10 +333,10 @@ class TestResolveNamespaceAndChannel:
         ]
 
         with patch("binstar_client.commands._repo_channels.select_from_list", return_value="org-b"):
-            ns, ch = _resolve_namespace_and_channel(mock_api, "dev")
+            resolved = _resolve_namespace_and_channel(mock_api, "dev")
 
-        assert ns == "org-b"
-        assert ch == "dev"
+        assert resolved.namespace == "org-b"
+        assert resolved.channel_name == "dev"
 
 
 class TestRepoCoreChannelsCLI:

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -1,6 +1,6 @@
 """Tests for the repocore client and CLI commands."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from typer.testing import CliRunner
@@ -392,7 +392,7 @@ class TestRepoCoreChannelsCLI:
         app = _get_channels_app()
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = []
-        mock_api.account = {"user": {"username": "testuser"}}
+        type(mock_api).account = PropertyMock(return_value={"user": {"username": "testuser"}})
         mock_api.create_namespace_channel.return_value = {"channel_path": "testuser/newchannel"}
 
         with _patch_repo_api(mock_api):


### PR DESCRIPTION
https://anaconda.atlassian.net/browse/HUB-3368

Instead of retrieving top-level channels a user has access to, a call is instead made to auth services for organizations a user is in, which will have a repocore namespace that is the org name.

There are also two repocore-specific product decisions included
- Prompt for privacy if a privacy flag is not included in the command, defaults to private
- Requires confirmation if a user is not in an org to automatically create a namespace that is their username. This is because we are doing something on their behalf they might be unaware of. If they use the --namespace option or slash channel string, there is no prompt.
- Pydantic models for namespaces and channels