### PR TITLE
HUB-3404_fix_login_loop_and_correct_help

### DIFF
--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -168,8 +168,8 @@ def _upload_file_to_channel(
                 f"Status: {response.status_code}\n"
                 f"Details: {response.content.decode()}"
             )
-    except Unauthorized:
-        console.print("[red]Error:[/red] Authentication failed. Please run 'anaconda login'.")
+    except Unauthorized as e:
+        console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)
     except RepoCoreError as e:
         console.print(f"[red]Error:[/red] {e}")

--- a/binstar_client/commands/channel.py
+++ b/binstar_client/commands/channel.py
@@ -69,7 +69,7 @@ def _add_parser(subparsers, name, deprecated=False):
         name,
         help='{}Manage your Anaconda repository {}s'.format(deprecated_warn, name),
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description=__doc__,
+        description=f'Manage your Anaconda repository {name}s.',
     )
 
     subparser.add_argument('-o', '--organization', help='Manage an organizations {}s'.format(name))

--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -388,13 +388,7 @@ if not isinstance(main_app, functools.partial):
 def _handle_login_required(e: Exception) -> int:
     import sys
 
-    detail = getattr(e, "detail", None)
-    if isinstance(detail, dict):
-        msg = detail.get("message") or detail.get("detail") or str(detail)
-    elif detail:
-        msg = str(detail)
-    else:
-        msg = "authentication required"
+    msg = str(e)
     print(f"Login failed: {msg}", file=sys.stderr)
     print("Please run 'anaconda login' and try again.", file=sys.stderr)
 

--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -381,11 +381,21 @@ from binstar_client.repocore.errors import LoginRequiredError  # noqa: E402
 
 app.add_typer(channel_app)
 if not isinstance(main_app, functools.partial):
-    main_app.add_typer(channel_app)
+    main_app.add_typer(channel_app, help="Manage your Anaconda repository channels (alias for 'anaconda org channel')")
 
 
 @register_error_handler(LoginRequiredError)
 def _handle_login_required(e: Exception) -> int:
-    from anaconda_auth.cli import _continue_with_login
+    import sys
 
-    return _continue_with_login()
+    detail = getattr(e, "detail", None)
+    if isinstance(detail, dict):
+        msg = detail.get("message") or detail.get("detail") or str(detail)
+    elif detail:
+        msg = str(detail)
+    else:
+        msg = "authentication required"
+    print(f"Login failed: {msg}", file=sys.stderr)
+    print("Please run 'anaconda login' and try again.", file=sys.stderr)
+
+    return 1

--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -29,7 +29,6 @@ import typer.colors
 from anaconda_cli_base import console, __version__
 from anaconda_cli_base.cli import app as main_app, ContextExtras
 
-from anaconda_cli_base.exceptions import register_error_handler
 
 from binstar_client import commands as command_module
 from binstar_client.scripts.cli import (
@@ -377,19 +376,6 @@ load_legacy_subcommands()
 
 # Mount repocore channel command under `anaconda org channel` and `anaconda channel`
 from binstar_client.commands._repo_channels import app as channel_app  # noqa: E402
-from binstar_client.repocore.errors import LoginRequiredError  # noqa: E402
-
 app.add_typer(channel_app)
 if not isinstance(main_app, functools.partial):
     main_app.add_typer(channel_app, help="Manage your Anaconda repository channels (alias for 'anaconda org channel')")
-
-
-@register_error_handler(LoginRequiredError)
-def _handle_login_required(e: Exception) -> int:
-    import sys
-
-    msg = str(e)
-    print(f"Login failed: {msg}", file=sys.stderr)
-    print("Please run 'anaconda login' and try again.", file=sys.stderr)
-
-    return 1

--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -376,6 +376,7 @@ load_legacy_subcommands()
 
 # Mount repocore channel command under `anaconda org channel` and `anaconda channel`
 from binstar_client.commands._repo_channels import app as channel_app  # noqa: E402
+
 app.add_typer(channel_app)
 if not isinstance(main_app, functools.partial):
     main_app.add_typer(channel_app, help="Manage your Anaconda repository channels (alias for 'anaconda org channel')")

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 from anaconda_auth.client import BaseClient
 
-from binstar_client.repocore.errors import InvalidName, LoginRequiredError, RepoCoreError, Unauthorized
+from binstar_client.repocore.errors import InvalidName, RepoCoreError, Unauthorized
 from binstar_client.repocore.models import (
     Channel,
     Namespace,
@@ -120,9 +120,7 @@ class RepoCoreClient(BaseClient):
 
         msg = self._extract_error_message(response, action)
 
-        if response.status_code == 401:
-            raise LoginRequiredError(detail=msg)
-        if response.status_code == 403:
+        if response.status_code in (401, 403):
             raise Unauthorized(msg)
 
         raise RepoCoreError(msg)

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -104,8 +104,8 @@ class RepoCoreClient(BaseClient):
             if isinstance(data, dict):
                 error = data.get("error")
                 if isinstance(error, dict):
-                    return error.get("message") or error.get("detail") or str(error)
-                return data.get("message") or data.get("detail") or error or ""
+                    error = error.get("message") or error.get("detail") or ""
+                return data.get("message") or data.get("detail") or str(error or "")
         except (ValueError, KeyError):
             pass
         return f"Error {action} (status {response.status_code})"

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -102,7 +102,10 @@ class RepoCoreClient(BaseClient):
         try:
             data = response.json()
             if isinstance(data, dict):
-                return data.get("message") or data.get("detail") or data.get("error", "")
+                error = data.get("error")
+                if isinstance(error, dict):
+                    return error.get("message") or error.get("detail") or str(error)
+                return data.get("message") or data.get("detail") or error or ""
         except (ValueError, KeyError):
             pass
         return f"Error {action} (status {response.status_code})"
@@ -118,7 +121,7 @@ class RepoCoreClient(BaseClient):
         msg = self._extract_error_message(response, action)
 
         if response.status_code == 401:
-            raise LoginRequiredError()
+            raise LoginRequiredError(detail=msg)
         if response.status_code == 403:
             raise Unauthorized(msg)
 

--- a/binstar_client/repocore/errors.py
+++ b/binstar_client/repocore/errors.py
@@ -15,8 +15,9 @@ class Unauthorized(RepoCoreError):
 
 
 class LoginRequiredError(RepoCoreError):
-    def __init__(self):
-        super().__init__("Authentication required. Please run 'anaconda login' and try again.")
+    def __init__(self, detail=None):
+        self.detail = detail
+        super().__init__(detail or "Authentication required")
 
 
 class InvalidName(RepoCoreError):

--- a/binstar_client/repocore/errors.py
+++ b/binstar_client/repocore/errors.py
@@ -15,10 +15,8 @@ class Unauthorized(RepoCoreError):
 
 
 class LoginRequiredError(RepoCoreError):
-    def __init__(self, detail=None):
-        self.detail = detail
-        super().__init__(detail or "Authentication required")
-
+    def __init__(self):
+        super().__init__("Authentication required. Please run 'anaconda login' and try again.")
 
 class InvalidName(RepoCoreError):
     pass

--- a/binstar_client/repocore/errors.py
+++ b/binstar_client/repocore/errors.py
@@ -18,6 +18,7 @@ class LoginRequiredError(RepoCoreError):
     def __init__(self):
         super().__init__("Authentication required. Please run 'anaconda login' and try again.")
 
+
 class InvalidName(RepoCoreError):
     pass
 

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -228,7 +228,6 @@ class TestRepoCoreClientAPI:
             client._manage_response(mock_response, "test action")
 
 
-
 class TestRepoCoreNamespaceChannel:
     def test_create_namespace_channel(self):
         client = _make_client()

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -231,7 +231,7 @@ class TestRepoCoreClientAPI:
 class TestLoginRequiredErrorHandler:
     @pytest.fixture(autouse=True)
     def _register_handler(self):
-        """Register the handler matching plugins.py logic for test isolation."""
+        """Register the handler for test isolation (plugins.py cannot be imported directly)."""
         from anaconda_cli_base.exceptions import ERROR_HANDLERS, register_error_handler
 
         if LoginRequiredError not in ERROR_HANDLERS:
@@ -240,14 +240,7 @@ class TestLoginRequiredErrorHandler:
             def _handle_login_required(e):
                 import sys
 
-                detail = getattr(e, "detail", None)
-                if isinstance(detail, dict):
-                    msg = detail.get("message") or detail.get("detail") or str(detail)
-                elif detail:
-                    msg = str(detail)
-                else:
-                    msg = "authentication required"
-                print(f"Login failed: {msg}", file=sys.stderr)
+                print(f"Login failed: {str(e)}", file=sys.stderr)
                 print("Please run 'anaconda login' and try again.", file=sys.stderr)
                 return 1
 

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -208,9 +208,9 @@ class TestRepoCoreClientAPI:
 
     def test_manage_response_401_raises_login_required(self):
         client = _make_client()
-        mock_response = _mock_response(401, {"error": {"code": "auth_required"}})
+        mock_response = _mock_response(401, {"error": {"code": "auth_required", "message": "Invalid token"}})
 
-        with pytest.raises(LoginRequiredError, match="Authentication required"):
+        with pytest.raises(LoginRequiredError, match="Invalid token"):
             client._manage_response(mock_response, "test action")
 
     def test_manage_response_403(self):
@@ -229,28 +229,48 @@ class TestRepoCoreClientAPI:
 
 
 class TestLoginRequiredErrorHandler:
-    def test_handler_is_registered(self):
+    @pytest.fixture(autouse=True)
+    def _register_handler(self):
+        """Register the handler matching plugins.py logic for test isolation."""
         from anaconda_cli_base.exceptions import ERROR_HANDLERS, register_error_handler
 
-        # Ensure registration (normally done by plugins.py at CLI startup)
         if LoginRequiredError not in ERROR_HANDLERS:
 
             @register_error_handler(LoginRequiredError)
-            def _handler(e):
-                from anaconda_auth.cli import _continue_with_login
+            def _handle_login_required(e):
+                import sys
 
-                return _continue_with_login()
+                detail = getattr(e, "detail", None)
+                if isinstance(detail, dict):
+                    msg = detail.get("message") or detail.get("detail") or str(detail)
+                elif detail:
+                    msg = str(detail)
+                else:
+                    msg = "authentication required"
+                print(f"Login failed: {msg}", file=sys.stderr)
+                print("Please run 'anaconda login' and try again.", file=sys.stderr)
+                return 1
+
+    def test_handler_is_registered(self):
+        from anaconda_cli_base.exceptions import ERROR_HANDLERS
 
         assert LoginRequiredError in ERROR_HANDLERS
 
-    def test_handler_calls_continue_with_login(self):
+    def test_handler_returns_exit_code_1(self):
         from anaconda_cli_base.exceptions import ERROR_HANDLERS
 
         handler = ERROR_HANDLERS[LoginRequiredError]
-        with patch("anaconda_auth.cli._continue_with_login", return_value=1) as mock_login:
-            result = handler(LoginRequiredError())
-            mock_login.assert_called_once()
-            assert result == 1
+        result = handler(LoginRequiredError())
+        assert result == 1
+
+    def test_handler_prints_detail(self, capsys):
+        from anaconda_cli_base.exceptions import ERROR_HANDLERS
+
+        handler = ERROR_HANDLERS[LoginRequiredError]
+        result = handler(LoginRequiredError(detail="Invalid API key"))
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Invalid API key" in captured.err
 
 
 class TestRepoCoreNamespaceChannel:

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -14,7 +14,6 @@ from binstar_client.repocore import (
 )
 from binstar_client.repocore.errors import (
     InvalidName,
-    LoginRequiredError,
     RepoCoreError,
     Unauthorized,
 )
@@ -206,11 +205,11 @@ class TestRepoCoreClientAPI:
         call_args = client.put.call_args
         assert call_args[1]["json"] == {"privacy": "private"}
 
-    def test_manage_response_401_raises_login_required(self):
+    def test_manage_response_401_raises_unauthorized(self):
         client = _make_client()
         mock_response = _mock_response(401, {"error": {"code": "auth_required", "message": "Invalid token"}})
 
-        with pytest.raises(LoginRequiredError, match="Invalid token"):
+        with pytest.raises(Unauthorized, match="Invalid token"):
             client._manage_response(mock_response, "test action")
 
     def test_manage_response_403(self):
@@ -830,7 +829,7 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["upload", "test-1.0-py39_0.conda", "--channel", "dev"])
 
         assert result.exit_code == 1
-        assert "Authentication failed" in result.output
+        assert "does not allow you to perform this operation" in result.output
 
     def test_upload_repocore_error(self):
         runner = CliRunner()
@@ -865,7 +864,7 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["upload", "test-1.0-py39_0.conda", "--channel", "dev"])
 
         assert result.exit_code == 1
-        assert "Authentication failed" in result.output
+        assert "does not allow you to perform this operation" in result.output
 
     def test_upload_error_response(self):
         runner = CliRunner()

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -228,43 +228,6 @@ class TestRepoCoreClientAPI:
             client._manage_response(mock_response, "test action")
 
 
-class TestLoginRequiredErrorHandler:
-    @pytest.fixture(autouse=True)
-    def _register_handler(self):
-        """Register the handler for test isolation (plugins.py cannot be imported directly)."""
-        from anaconda_cli_base.exceptions import ERROR_HANDLERS, register_error_handler
-
-        if LoginRequiredError not in ERROR_HANDLERS:
-
-            @register_error_handler(LoginRequiredError)
-            def _handle_login_required(e):
-                import sys
-
-                print(f"Login failed: {str(e)}", file=sys.stderr)
-                print("Please run 'anaconda login' and try again.", file=sys.stderr)
-                return 1
-
-    def test_handler_is_registered(self):
-        from anaconda_cli_base.exceptions import ERROR_HANDLERS
-
-        assert LoginRequiredError in ERROR_HANDLERS
-
-    def test_handler_returns_exit_code_1(self):
-        from anaconda_cli_base.exceptions import ERROR_HANDLERS
-
-        handler = ERROR_HANDLERS[LoginRequiredError]
-        result = handler(LoginRequiredError())
-        assert result == 1
-
-    def test_handler_prints_detail(self, capsys):
-        from anaconda_cli_base.exceptions import ERROR_HANDLERS
-
-        handler = ERROR_HANDLERS[LoginRequiredError]
-        result = handler(LoginRequiredError(detail="Invalid API key"))
-        assert result == 1
-        captured = capsys.readouterr()
-        assert "Invalid API key" in captured.err
-
 
 class TestRepoCoreNamespaceChannel:
     def test_create_namespace_channel(self):


### PR DESCRIPTION
- We were incorrectly raising a login exception when it was a repocore auth error. This fixes the loop by raising the error instead of calling the interactive login.
- This PR also corrects some inaccurate help text