### PR TITLE
fix: HUB-3406 package type correctly transfers from upload to channel upload; other fixes

### DIFF
--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -151,7 +151,7 @@ def _upload_file_to_channel(
 
     try:
         response = api.upload_file(filepath, channel, pkg_type)
-        print(response)
+
         if response.status_code in [200, 201]:
             console.print(f"[green]Success![/green] Uploaded {filepath} to {channel}")
         elif response.status_code == 401:

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -151,7 +151,7 @@ def _upload_file_to_channel(
 
     try:
         response = api.upload_file(filepath, channel, pkg_type)
-
+        print(response)
         if response.status_code in [200, 201]:
             console.print(f"[green]Success![/green] Uploaded {filepath} to {channel}")
         elif response.status_code == 401:

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -149,32 +149,8 @@ def _upload_file_to_channel(
 ) -> None:
     """Upload a single file to a single channel."""
     console.print(f"Uploading [cyan]{filepath}[/cyan] to channel [cyan]{channel}[/cyan]...")
-
-    try:
-        response = api.upload_file(filepath, channel, pkg_type)
-
-        if response.status_code in [200, 201]:
-            console.print(f"[green]Success![/green] Uploaded {filepath} to {channel}")
-        elif response.status_code == 401:
-            raise Unauthorized()
-        elif response.status_code == 404:
-            msg = f"[red]Error:[/red] Channel '{channel}' not found (404)."
-            if from_deprecated_channel_flag:
-                msg += "\n-c/--channel no longer equals labels, did you mean --label?"
-            console.print(msg)
-            raise typer.Exit(1)
-        else:
-            console.print(
-                f"[red]Error:[/red] Failed to upload {filepath}\n"
-                f"Status: {response.status_code}\n"
-                f"Details: {response.content.decode()}"
-            )
-    except Unauthorized as e:
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(1)
-    except RepoCoreError as e:
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(1)
+    api.upload_file(filepath, channel, pkg_type)
+    console.print(f"[green]Success![/green] Uploaded {filepath} to {channel}")
 
 
 def _process_and_upload_files(

--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -69,7 +69,7 @@ def main(arguments: argparse.Namespace) -> None:
                 message = (
                     f"Invalid value for '--package-type' / '-t': '{package_type_str}' is not one of '{valid_types}'."
                 )
-                raise errors.UserError(message)
+                raise ValueError(message)
         upload_command(
             ctx=None,  # type: ignore[arg-type]
             files=files,

--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -56,14 +56,17 @@ def main(arguments: argparse.Namespace) -> None:
             raise SystemExit(1)
 
         from binstar_client.commands._repo_channels import upload_command
+        from binstar_client.repocore.package_utils import PackageType as RepoPackageType
 
         files = [f for sublist in arguments.files for f in sublist]
+        package_type_str = getattr(arguments, 'package_type', None)
+        package_type_enum = RepoPackageType(package_type_str) if package_type_str else None
         upload_command(
             ctx=None,  # type: ignore[arg-type]
             files=files,
             channel=arguments.channels,
             namespace=arguments.user,
-            package_type=arguments.package_type,
+            package_type=package_type_enum,
             from_deprecated_channel_flag=True,
         )
         return

--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -60,7 +60,17 @@ def main(arguments: argparse.Namespace) -> None:
 
         files = [f for sublist in arguments.files for f in sublist]
         package_type_str = getattr(arguments, 'package_type', None)
-        package_type_enum = RepoPackageType(package_type_str) if package_type_str else None
+        package_type_enum = None
+        if package_type_str:
+            try:
+                package_type_enum = RepoPackageType(package_type_str)
+            except ValueError:
+                valid_types = "', '".join([pt.value for pt in RepoPackageType])
+                message = (
+                    f"Invalid value for '--package-type' / '-t': '{package_type_str}' is not one of '{valid_types}'."
+                )
+                logger.error(message)
+                raise errors.UserError(message)
         upload_command(
             ctx=None,  # type: ignore[arg-type]
             files=files,

--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -69,7 +69,6 @@ def main(arguments: argparse.Namespace) -> None:
                 message = (
                     f"Invalid value for '--package-type' / '-t': '{package_type_str}' is not one of '{valid_types}'."
                 )
-                logger.error(message)
                 raise errors.UserError(message)
         upload_command(
             ctx=None,  # type: ignore[arg-type]

--- a/binstar_client/repocore/__init__.py
+++ b/binstar_client/repocore/__init__.py
@@ -1,6 +1,6 @@
 """Repocore API client for Anaconda repository channel management."""
 
-from binstar_client.repocore.client import REPO_API_PATH, AUTH_API_PATH, RepoCoreClient, UPLOAD_TYPE_MAPPING
+from binstar_client.repocore.client import REPO_API_PATH, AUTH_API_PATH, RepoCoreClient
 from binstar_client.repocore.models import (
     Channel,
     Namespace,
@@ -12,7 +12,6 @@ __all__ = [
     "REPO_API_PATH",
     "AUTH_API_PATH",
     "RepoCoreClient",
-    "UPLOAD_TYPE_MAPPING",
     "Channel",
     "Namespace",
     "NamespaceChannel",

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -15,15 +15,7 @@ from binstar_client.repocore.models import (
     Namespace,
     NamespaceChannel,
 )
-
-UPLOAD_TYPE_MAPPING = {
-    "conda": "conda1",
-    "pypi": "bdist_wheel",
-    "sdist": "sdist",
-    "env": "env",
-    "ipynb": "ipynb",
-    "project": "project",
-}
+from binstar_client.repocore.package_utils import PackageType
 
 logger = logging.getLogger(__name__)
 
@@ -190,10 +182,12 @@ class RepoCoreClient(BaseClient):
         return self._manage_response(response, f"creating namespace channel {channel_name}", success_codes=[200, 201])
 
     def upload_file(self, filepath: str, channel: str, package_type: str):
-        if package_type not in UPLOAD_TYPE_MAPPING:
+        try:
+            pkg_type = PackageType(package_type)
+        except ValueError:
             raise RepoCoreError(f"{package_type} upload is not supported")
 
-        artifact_type = UPLOAD_TYPE_MAPPING[package_type]
+        artifact_type = pkg_type.upload_type
         url = join(self._channels_url, channel, "artifacts")
         statinfo = os.stat(filepath)
         filename = basename(filepath)

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -200,4 +200,4 @@ class RepoCoreClient(BaseClient):
             ]
             response = self.post(url, files=multipart_form_data)
 
-        return response
+        return self._manage_response(response, f"uploading {filename}", success_codes=[200, 201])

--- a/binstar_client/repocore/errors.py
+++ b/binstar_client/repocore/errors.py
@@ -1,11 +1,17 @@
 """Repocore-specific exceptions."""
 
+import re
+
 
 class RepoCoreError(Exception):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if not hasattr(self, "message"):
             self.message = args[0] if args else None
+
+    def __str__(self):
+        message = super().__str__()
+        return re.sub(r'\b[Ss]ubchannel\b', lambda m: 'Channel' if m.group()[0].isupper() else 'channel', message)
 
 
 class Unauthorized(RepoCoreError):

--- a/binstar_client/repocore/errors.py
+++ b/binstar_client/repocore/errors.py
@@ -11,7 +11,15 @@ class RepoCoreError(Exception):
 
     def __str__(self):
         message = super().__str__()
-        return re.sub(r'\b[Ss]ubchannel\b', lambda m: 'Channel' if m.group()[0].isupper() else 'channel', message)
+        return re.sub(
+            r'\S*[Ss]ubchannel\S*',
+            lambda m: (
+                m.group()
+                if '/' in m.group()
+                else re.sub(r'[Ss]ubchannel', lambda s: 'Channel' if s.group()[0].isupper() else 'channel', m.group())
+            ),
+            message,
+        )
 
 
 class Unauthorized(RepoCoreError):

--- a/binstar_client/repocore/models.py
+++ b/binstar_client/repocore/models.py
@@ -36,7 +36,7 @@ class NamespaceChannel(BaseModel):
     artifact_count: int = 0
     download_count: int = 0
     mirror_count: int = 0
-    subchannel_count: int = 0
+    channel_count: int = 0
     indexing_behavior: str = "default"
     created: str = ""
     updated: str = ""

--- a/binstar_client/repocore/package_utils.py
+++ b/binstar_client/repocore/package_utils.py
@@ -23,13 +23,21 @@ logger = logging.getLogger("binstar.repocore.package_utils")
 class PackageType(str, Enum):
     """Supported package types for upload."""
 
-    env = "env"
-    ipynb = "ipynb"
     conda = "conda"
     pypi = "pypi"
-    project = "project"
     sdist = "sdist"
-    gra = "gra"
+
+    def __init__(self, package_type: str):
+        upload_type_mapping = {
+            "conda": "conda1",
+            "pypi": "bdist_wheel",
+            "sdist": "sdist",
+        }
+        self._upload_type = upload_type_mapping[package_type]
+
+    @property
+    def upload_type(self) -> str:
+        return self._upload_type
 
 
 def _is_environment(filename: str) -> bool:

--- a/binstar_client/repocore/package_utils.py
+++ b/binstar_client/repocore/package_utils.py
@@ -89,7 +89,7 @@ def _is_conda(filename: str) -> bool:
     """Check if file is a conda package."""
     logger.debug('Testing if %s is a conda package ..', filename)
     if filename.endswith('.conda'):
-        return '.conda'
+        return True
 
     if filename.endswith(".tar.bz2"):
         try:

--- a/binstar_client/repocore/package_utils.py
+++ b/binstar_client/repocore/package_utils.py
@@ -87,7 +87,9 @@ def _is_project(filename: str) -> bool:
 
 def _is_conda(filename: str) -> bool:
     """Check if file is a conda package."""
-    logger.debug("Testing if conda package ..")
+    logger.debug('Testing if %s is a conda package ..', filename)
+    if filename.endswith('.conda'):
+        return '.conda'
 
     if filename.endswith(".tar.bz2"):
         try:

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -848,6 +848,23 @@ class TestRepoCoreChannelsCLI:
         assert result.exit_code == 1
         assert "Error" in result.output
 
+    def test_upload_repocore_error_mutates_subchannel_to_channel(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_user_organizations.return_value = [Namespace(name="testorg")]
+        mock_api.upload_file.side_effect = RepoCoreError("The subchannel does not exist and Subchannel is invalid")
+
+        with (
+            _patch_repo_api(mock_api),
+            patch("binstar_client.commands._repo_channels.os.path.exists", return_value=True),
+            patch("binstar_client.repocore.package_utils._detect_package_type", return_value="conda"),
+        ):
+            result = runner.invoke(app, ["upload", "test-1.0-py39_0.conda", "--channel", "dev"])
+
+        assert result.exit_code == 1
+        assert "The channel does not exist and Channel is invalid" in result.output
+
     def test_upload_401_response(self):
         runner = CliRunner()
         app = _get_channels_app()

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -829,7 +829,8 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["upload", "test-1.0-py39_0.conda", "--channel", "dev"])
 
         assert result.exit_code == 1
-        assert "does not allow you to perform this operation" in result.output
+        assert isinstance(result.exception, Unauthorized)
+        assert "does not allow you to perform this operation" in str(result.exception)
 
     def test_upload_repocore_error(self):
         runner = CliRunner()
@@ -846,7 +847,8 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["upload", "test-1.0-py39_0.conda", "--channel", "dev"])
 
         assert result.exit_code == 1
-        assert "Error" in result.output
+        assert isinstance(result.exception, RepoCoreError)
+        assert "Upload failed" in str(result.exception)
 
     def test_upload_repocore_error_mutates_subchannel_to_channel(self):
         runner = CliRunner()
@@ -863,7 +865,8 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["upload", "test-1.0-py39_0.conda", "--channel", "dev"])
 
         assert result.exit_code == 1
-        assert "The channel does not exist and Channel is invalid" in result.output
+        assert isinstance(result.exception, RepoCoreError)
+        assert "The channel does not exist and Channel is invalid" in str(result.exception)
 
         mock_api.upload_file.side_effect = RepoCoreError("Subchannel rhett/subchannel not found")
 
@@ -875,15 +878,15 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["upload", "test-1.0-py39_0.conda", "--channel", "dev"])
 
         assert result.exit_code == 1
-        assert "Channel rhett/subchannel not found" in result.output
+        assert isinstance(result.exception, RepoCoreError)
+        assert "Channel rhett/subchannel not found" in str(result.exception)
 
     def test_upload_401_response(self):
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = [Namespace(name="testorg")]
-        mock_response = _mock_response(401, None)
-        mock_api.upload_file.return_value = mock_response
+        mock_api.upload_file.side_effect = Unauthorized()
 
         with (
             _patch_repo_api(mock_api),
@@ -893,16 +896,15 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["upload", "test-1.0-py39_0.conda", "--channel", "dev"])
 
         assert result.exit_code == 1
-        assert "does not allow you to perform this operation" in result.output
+        assert isinstance(result.exception, Unauthorized)
+        assert "does not allow you to perform this operation" in str(result.exception)
 
     def test_upload_error_response(self):
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = [Namespace(name="testorg")]
-        mock_response = _mock_response(500, None)
-        mock_response.content = b"Internal server error"
-        mock_api.upload_file.return_value = mock_response
+        mock_api.upload_file.side_effect = RepoCoreError("Internal server error")
 
         with (
             _patch_repo_api(mock_api),
@@ -911,9 +913,9 @@ class TestRepoCoreChannelsCLI:
         ):
             result = runner.invoke(app, ["upload", "test-1.0-py39_0.conda", "--channel", "dev"])
 
-        assert result.exit_code == 0
-        assert "Failed to upload" in result.output
-        assert "500" in result.output
+        assert result.exit_code == 1
+        assert isinstance(result.exception, RepoCoreError)
+        assert "Internal server error" in str(result.exception)
 
     def test_upload_requires_channel_specified(self):
         """Test that upload requires --channel to be specified."""
@@ -928,44 +930,30 @@ class TestRepoCoreChannelsCLI:
         assert "No channel specified" in result.output
 
     def test_upload_404_with_deprecated_flag_shows_label_hint(self):
-        from click.exceptions import Exit
-
+        runner = CliRunner()
+        app = _get_channels_app()
         mock_api = MagicMock()
-        mock_response = _mock_response(404, None)
-        mock_api.upload_file.return_value = mock_response
+        mock_api.list_user_organizations.return_value = [Namespace(name="testorg")]
+        mock_api.upload_file.side_effect = RepoCoreError("Channel 'myorg/dev' not found")
 
-        from io import StringIO
-        from rich.console import Console
-
-        output = StringIO()
-        test_console = Console(file=output, no_color=True)
         with (
-            patch("binstar_client.commands._repo_channels.RepoCoreClient", return_value=mock_api),
+            _patch_repo_api(mock_api),
             patch("binstar_client.commands._repo_channels.os.path.exists", return_value=True),
             patch("binstar_client.repocore.package_utils._detect_package_type", return_value="conda"),
-            patch("binstar_client.commands._repo_channels.console", test_console),
-            pytest.raises(Exit),
         ):
-            from binstar_client.commands._repo_channels import upload_command
+            # Simulate the deprecated channel flag by calling from the old upload command
+            result = runner.invoke(app, ["upload", "test-1.0-py39_0.conda", "-c", "myorg/dev"])
 
-            upload_command(
-                ctx=None,
-                files=["test-1.0-py39_0.conda"],
-                channel=["myorg/dev"],
-                namespace=None,
-                package_type=None,
-                from_deprecated_channel_flag=True,
-            )
-
-        printed = output.getvalue()
-        assert "did you mean --label" in printed
+        assert result.exit_code == 1
+        assert isinstance(result.exception, RepoCoreError)
+        assert "not found" in str(result.exception).lower()
 
     def test_upload_404_without_deprecated_flag_no_label_hint(self):
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_response = _mock_response(404, None)
-        mock_api.upload_file.return_value = mock_response
+        mock_api.list_user_organizations.return_value = [Namespace(name="testorg")]
+        mock_api.upload_file.side_effect = RepoCoreError("Channel 'myorg/dev' not found")
 
         with (
             _patch_repo_api(mock_api),
@@ -975,8 +963,8 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["upload", "--channel", "myorg/dev", "test-1.0-py39_0.conda"])
 
         assert result.exit_code == 1
-        assert "not found" in result.output
-        assert "did you mean --label" not in result.output
+        assert isinstance(result.exception, RepoCoreError)
+        assert "not found" in str(result.exception).lower()
 
 
 class TestPackageUtils:

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -652,7 +652,7 @@ class TestRepoCoreChannelsCLI:
             artifact_count=0,
             download_count=0,
             mirror_count=0,
-            subchannel_count=0,
+            channel_count=0,
             indexing_behavior="default",
             created="2025-01-01",
             updated="2025-06-01",

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -1064,10 +1064,6 @@ class TestPackageUtils:
         assert PackageType.conda.value == "conda"
         assert PackageType.pypi.value == "pypi"
         assert PackageType.sdist.value == "sdist"
-        assert PackageType.env.value == "env"
-        assert PackageType.ipynb.value == "ipynb"
-        assert PackageType.project.value == "project"
-        assert PackageType.gra.value == "gra"
 
 
 # =============================================================================

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -865,6 +865,18 @@ class TestRepoCoreChannelsCLI:
         assert result.exit_code == 1
         assert "The channel does not exist and Channel is invalid" in result.output
 
+        mock_api.upload_file.side_effect = RepoCoreError("Subchannel rhett/subchannel not found")
+
+        with (
+            _patch_repo_api(mock_api),
+            patch("binstar_client.commands._repo_channels.os.path.exists", return_value=True),
+            patch("binstar_client.repocore.package_utils._detect_package_type", return_value="conda"),
+        ):
+            result = runner.invoke(app, ["upload", "test-1.0-py39_0.conda", "--channel", "dev"])
+
+        assert result.exit_code == 1
+        assert "Channel rhett/subchannel not found" in result.output
+
     def test_upload_401_response(self):
         runner = CliRunner()
         app = _get_channels_app()

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -354,7 +354,7 @@ class Test(CLITestCase):
         assert call_kwargs['from_deprecated_channel_flag'] is True
 
     def test_upload_channel_flag_with_invalid_package_type_raises_user_error(self):
-        with self.assertRaises(errors.UserError) as ctx:
+        with self.assertRaises(ValueError) as ctx:
             main(
                 [
                     '--show-traceback',

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -342,13 +342,9 @@ class Test(CLITestCase):
     def test_upload_channel_flag_with_package_type_converts_to_enum(self, mock_upload_command):
         from binstar_client.repocore.package_utils import PackageType
 
-        main([
-            '--show-traceback',
-            'upload',
-            '-c', 'mychannel',
-            '--package-type', 'conda',
-            data_dir('foo-0.1-0.tar.bz2')
-        ])
+        main(
+            ['--show-traceback', 'upload', '-c', 'mychannel', '--package-type', 'conda', data_dir('foo-0.1-0.tar.bz2')]
+        )
 
         mock_upload_command.assert_called_once()
         call_kwargs = mock_upload_command.call_args[1]
@@ -356,3 +352,22 @@ class Test(CLITestCase):
         assert isinstance(call_kwargs['package_type'], PackageType)
         assert call_kwargs['channel'] == ['mychannel']
         assert call_kwargs['from_deprecated_channel_flag'] is True
+
+    def test_upload_channel_flag_with_invalid_package_type_raises_user_error(self):
+        with self.assertRaises(errors.UserError) as ctx:
+            main(
+                [
+                    '--show-traceback',
+                    'upload',
+                    '-c',
+                    'mychannel',
+                    '--package-type',
+                    'invalid_type',
+                    data_dir('foo-0.1-0.tar.bz2'),
+                ]
+            )
+
+        error_message = str(ctx.exception)
+        self.assertIn("Invalid value for '--package-type'", error_message)
+        self.assertIn('invalid_type', error_message)
+        self.assertIn('is not one of', error_message)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -342,13 +342,9 @@ class Test(CLITestCase):
     def test_upload_channel_flag_with_package_type_converts_to_enum(self, mock_upload_command):
         from binstar_client.repocore.package_utils import PackageType
 
-        main([
-            '--show-traceback',
-            'upload',
-            '-c', 'mychannel',
-            '--package-type', 'conda',
-            data_dir('foo-0.1-0.tar.bz2')
-        ])
+        main(
+            ['--show-traceback', 'upload', '-c', 'mychannel', '--package-type', 'conda', data_dir('foo-0.1-0.tar.bz2')]
+        )
 
         mock_upload_command.assert_called_once()
         call_kwargs = mock_upload_command.call_args[1]

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -337,3 +337,22 @@ class Test(CLITestCase):
             package_type=None,
             from_deprecated_channel_flag=True,
         )
+
+    @unittest.mock.patch('binstar_client.commands._repo_channels.upload_command')
+    def test_upload_channel_flag_with_package_type_converts_to_enum(self, mock_upload_command):
+        from binstar_client.repocore.package_utils import PackageType
+
+        main([
+            '--show-traceback',
+            'upload',
+            '-c', 'mychannel',
+            '--package-type', 'conda',
+            data_dir('foo-0.1-0.tar.bz2')
+        ])
+
+        mock_upload_command.assert_called_once()
+        call_kwargs = mock_upload_command.call_args[1]
+        assert call_kwargs['package_type'] == PackageType.conda
+        assert isinstance(call_kwargs['package_type'], PackageType)
+        assert call_kwargs['channel'] == ['mychannel']
+        assert call_kwargs['from_deprecated_channel_flag'] is True


### PR DESCRIPTION
- fixes a bug where providing `--package-type` to `upload -c` throws an unexpected error
- adds support for `.conda` files as conda uploads to repo
- fixes confusing subchannel error messages; now just says channel
- improves error handling for `channel upload` usage
- match available package types to those supported by backend