### PR TITLE
HUB-3370: Channel sharing

### DIFF
--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -309,6 +309,10 @@ def create_command(
     api = ctx.obj.repo_api
     resolved = _resolve_namespace_and_channel(api, name, namespace, require_namespace=False)
 
+    if not resolved.namespace:
+        console.print("[red]Error:[/red] Namespace is required. Specify one with --namespace or use namespace/channel format.")
+        raise typer.Exit(1)
+
     if public:
         privacy = "public"
     elif private:
@@ -487,7 +491,11 @@ def upload_command(
 @app.command(name="share", help="Share a channel with a user")
 def share_command(
     ctx: typer.Context,
-    user_email: str = typer.Argument(..., help="Email of the user to share with"),
+    user: str = typer.Argument(..., help="User ID, email, or username to share with"),
+    channels: Optional[List[str]] = typer.Argument(
+        None,
+        help="Channel(s) to share in format 'namespace/channel' or 'channel'.",
+    ),
     channel: Optional[List[str]] = typer.Option(
         None,
         "--channel",
@@ -500,27 +508,39 @@ def share_command(
         "-n",
         help="Namespace for the channel (alternative to namespace/channel format)",
     ),
+    role: Optional[str] = typer.Option(
+        None,
+        "--role",
+        "-r",
+        help="Role to grant: viewer (read) or collaborator (write).",
+    ),
+    unshare: bool = typer.Option(False, "--unshare", help="Unshare the channel instead of sharing"),
 ) -> None:
     """Share a channel with a user."""
     api = ctx.obj.repo_api
 
-    channels = channel or []
-    if not channels:
-        console.print("[red]Error:[/red] No channel specified. Use --channel option to specify channel(s) to share.")
+    all_channels = list(channels or []) + list(channel or [])
+    if not all_channels:
+        console.print("[red]Error:[/red] No channel specified. Provide channel(s) as arguments or use --channel option.")
         raise typer.Exit(1)
 
-    resolved_channels = _resolve_channels_with_namespaces(api, channels, namespace, False)
+    if role and role not in ("viewer", "collaborator"):
+        console.print("[red]Error:[/red] --role must be either 'viewer' or 'collaborator'.")
+        raise typer.Exit(1)
 
+    if not role and not unshare:
+        console.print()
+        role = select_from_list("Select role:", ["viewer", "collaborator"])
+
+    grant = "write" if role == "collaborator" else "read"
+
+    resolved_channels = _resolve_channels_with_namespaces(api, all_channels, namespace, False)
+
+    action = "unshare" if unshare else "share"
     for ch in resolved_channels:
-        try:
-            api.share_channel(ch, user_email)
-            console.print(f"[green]Success![/green] Shared channel '[cyan]{ch}[/cyan]' with {user_email}")
-        except NotImplementedError as e:
-            console.print(f"[yellow]Note:[/yellow] {e}")
-            raise typer.Exit(1)
-        except RepoCoreError as e:
-            console.print(f"[red]Error:[/red] Failed to share channel {ch}: {e}")
-            raise typer.Exit(1)
+        namespace, channel_name = ch.split("/", 1)
+        api.share_channel(namespace, channel_name, user, action=action, grant=grant)
+        console.print(f"[green]Success![/green] {action.capitalize()}d channel '[cyan]{ch}[/cyan]' with {user}")
 
 
 channel_notices.mount_notice_subcommand(app)

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -479,11 +479,11 @@ def share_command(
         "-n",
         help="Namespace for the channel (alternative to namespace/channel format)",
     ),
-    role: Optional[str] = typer.Option(
-        None,
+    role: str = typer.Option(
+        "viewer",
         "--role",
         "-r",
-        help="Role to grant: viewer (read) or collaborator (write).",
+        help="Role to grant: viewer (read) or collaborator (write). Defaults to viewer.",
     ),
     unshare: bool = typer.Option(False, "--unshare", help="Unshare the channel instead of sharing"),
 ) -> None:
@@ -495,13 +495,9 @@ def share_command(
         console.print("[red]Error:[/red] No channel specified. Use --channel option to specify channel(s) to share.")
         raise typer.Exit(1)
 
-    if role and role not in ("viewer", "collaborator"):
+    if role not in ("viewer", "collaborator"):
         console.print("[red]Error:[/red] --role must be either 'viewer' or 'collaborator'.")
         raise typer.Exit(1)
-
-    if not role and not unshare:
-        console.print()
-        role = select_from_list("Select role:", ["viewer", "collaborator"])
 
     grant = "write" if role == "collaborator" else "read"
 

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -285,12 +285,6 @@ def create_command(
     api = ctx.obj.repo_api
     resolved = _resolve_namespace_and_channel(api, name, namespace, require_namespace=False)
 
-    if not resolved.namespace:
-        console.print(
-            "[red]Error:[/red] Namespace is required. Specify one with --namespace or use namespace/channel format."
-        )
-        raise typer.Exit(1)
-
     if public:
         privacy = "public"
     elif private:

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -189,7 +189,7 @@ def _resolve_namespace_and_channel(
       5. Calls _resolve_no_namespace if none are present
     """
     if "/" in name and namespace:
-        console.print("[red]Error:[/red] Ambiguous: name contains '/' but --namespace was also provided.")
+        console.print(f"[red]Error:[/red] Ambiguous: '{name}' contains '/' but --namespace was also provided.")
         raise typer.Exit(1)
 
     if "/" in name:
@@ -216,7 +216,7 @@ def _resolve_namespace_and_channel(
         return ResolvedChannel(namespace=namespaces[0], channel_name=name)
 
     console.print()
-    selected_namespace = select_from_list("Select namespace:", namespaces)
+    selected_namespace = select_from_list(f"Select namespace for channel '{name}':", namespaces)
     return ResolvedChannel(namespace=selected_namespace, channel_name=name)
 
 
@@ -286,7 +286,9 @@ def create_command(
     resolved = _resolve_namespace_and_channel(api, name, namespace, require_namespace=False)
 
     if not resolved.namespace:
-        console.print("[red]Error:[/red] Namespace is required. Specify one with --namespace or use namespace/channel format.")
+        console.print(
+            "[red]Error:[/red] Namespace is required. Specify one with --namespace or use namespace/channel format."
+        )
         raise typer.Exit(1)
 
     if public:
@@ -471,10 +473,6 @@ def upload_command(
 def share_command(
     ctx: typer.Context,
     user: str = typer.Argument(..., help="User ID, email, or username to share with"),
-    channels: Optional[List[str]] = typer.Argument(
-        None,
-        help="Channel(s) to share in format 'namespace/channel' or 'channel'.",
-    ),
     channel: Optional[List[str]] = typer.Option(
         None,
         "--channel",
@@ -498,9 +496,9 @@ def share_command(
     """Share a channel with a user."""
     api = ctx.obj.repo_api
 
-    all_channels = list(channels or []) + list(channel or [])
-    if not all_channels:
-        console.print("[red]Error:[/red] No channel specified. Provide channel(s) as arguments or use --channel option.")
+    channels = channel or []
+    if not channels:
+        console.print("[red]Error:[/red] No channel specified. Use --channel option to specify channel(s) to share.")
         raise typer.Exit(1)
 
     if role and role not in ("viewer", "collaborator"):
@@ -513,7 +511,7 @@ def share_command(
 
     grant = "write" if role == "collaborator" else "read"
 
-    resolved_channels = _resolve_channels_with_namespaces(api, all_channels, namespace, False)
+    resolved_channels = _resolve_channels_with_namespaces(api, channels, namespace, False)
 
     action = "unshare" if unshare else "share"
     for ch in resolved_channels:

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -484,4 +484,43 @@ def upload_command(
     _process_and_upload_files(api, files, resolved_channels, package_type, from_deprecated_channel_flag)
 
 
+@app.command(name="share", help="Share a channel with a user")
+def share_command(
+    ctx: typer.Context,
+    user_email: str = typer.Argument(..., help="Email of the user to share with"),
+    channel: Optional[List[str]] = typer.Option(
+        None,
+        "--channel",
+        "-c",
+        help="Channel(s) to share in format 'namespace/channel' or 'channel'. Can be specified multiple times.",
+    ),
+    namespace: Optional[str] = typer.Option(
+        None,
+        "--namespace",
+        "-n",
+        help="Namespace for the channel (alternative to namespace/channel format)",
+    ),
+) -> None:
+    """Share a channel with a user."""
+    api = ctx.obj.repo_api
+
+    channels = channel or []
+    if not channels:
+        console.print("[red]Error:[/red] No channel specified. Use --channel option to specify channel(s) to share.")
+        raise typer.Exit(1)
+
+    resolved_channels = _resolve_channels_with_namespaces(api, channels, namespace, False)
+
+    for ch in resolved_channels:
+        try:
+            api.share_channel(ch, user_email)
+            console.print(f"[green]Success![/green] Shared channel '[cyan]{ch}[/cyan]' with {user_email}")
+        except NotImplementedError as e:
+            console.print(f"[yellow]Note:[/yellow] {e}")
+            raise typer.Exit(1)
+        except RepoCoreError as e:
+            console.print(f"[red]Error:[/red] Failed to share channel {ch}: {e}")
+            raise typer.Exit(1)
+
+
 channel_notices.mount_notice_subcommand(app)

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -151,6 +151,7 @@ class RepoCoreClient(BaseClient):
     def remove_channel(self, channel: str):
         url = self._get_channel_url(channel)
         response = self.delete(url)
+        print(response.status_code)
         if response.status_code in [200, 202, 204]:
             return None
         msg = self._extract_error_message(response, f"removing channel {channel}")
@@ -207,3 +208,7 @@ class RepoCoreClient(BaseClient):
             response = self.post(url, files=multipart_form_data)
 
         return response
+
+    def share_channel(self, channel: str, user_email: str):
+        """Share a channel with a user. API implementation pending."""
+        raise NotImplementedError("Channel sharing API not yet implemented")

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -115,7 +115,7 @@ class RepoCoreClient(BaseClient):
           3. Extract error message
           4. If status code is 401 or 403, raise Unauthorized error with extracted msg
           5. If status code is any other, raise RepoCoreError with extracted msg
-        
+
         """
         if response.status_code in success_codes:
             if response.status_code in empty_success_codes:  # No Content responses
@@ -216,9 +216,6 @@ class RepoCoreClient(BaseClient):
         data = {"action": action, "user": user}
         if action == "share":
             data["grant"] = grant
-
-        print(f"Request url: {url}")
-        print(f"Request data: {data}")
 
         response = self.post(url, json=data)
         channel_path = f"{namespace}/{channel_name}"

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -110,11 +110,22 @@ class RepoCoreClient(BaseClient):
             pass
         return f"Error {action} (status {response.status_code})"
 
-    def _manage_response(self, response, action="", success_codes=None):
-        if not success_codes:
-            success_codes = [200]
+    def _manage_response(self, response, action="", success_codes=[200], empty_success_codes=[204]):
+        """Manages server responses
+
+        Defaults to success_codes of only 200 and No Content success code of 204.
+        Callers can pass their own success codes and empty success codes (No Content).
+
+        Resolution order:
+          1. If status code has no content (empty success code), return None
+          2. If status code is a non empty success code, return response.json()
+          3. Extract error message
+          4. If status code is 401 or 403, raise Unauthorized error with extracted msg
+          5. If status code is any other, raise RepoCoreError with extracted msg
+        
+        """
         if response.status_code in success_codes:
-            if response.status_code == 204:
+            if response.status_code in empty_success_codes:  # No Content responses
                 return None
             return response.json()
 
@@ -151,13 +162,9 @@ class RepoCoreClient(BaseClient):
     def remove_channel(self, channel: str):
         url = self._get_channel_url(channel)
         response = self.delete(url)
-        print(response.status_code)
-        if response.status_code in [200, 202, 204]:
-            return None
-        msg = self._extract_error_message(response, f"removing channel {channel}")
-        if response.status_code == 403:
-            raise Unauthorized(msg)
-        raise RepoCoreError(msg)
+        return self._manage_response(
+            response, f"removing channel {channel}", success_codes=[200, 202, 204], empty_success_codes=[200, 202, 204]
+        )
 
     def get_namespace_channel(self, channel: str) -> NamespaceChannel:
         url = self._get_channel_url(channel)
@@ -168,12 +175,9 @@ class RepoCoreClient(BaseClient):
     def update_channel(self, channel: str, **data):
         url = self._get_channel_url(channel)
         response = self.put(url, json=data)
-        if response.status_code in [200, 204]:
-            return None
-        msg = self._extract_error_message(response, f"updating channel {channel}")
-        if response.status_code == 403:
-            raise Unauthorized(msg)
-        raise RepoCoreError(msg)
+        return self._manage_response(
+            response, f"updating channel {channel}", success_codes=[200, 204], empty_success_codes=[200, 204]
+        )
 
     def get_channels(self, channel: str, offset: int = 0, limit: int = 50) -> list[Channel]:
         url = join(self._channels_url, channel, "subchannels")
@@ -209,6 +213,16 @@ class RepoCoreClient(BaseClient):
 
         return response
 
-    def share_channel(self, channel: str, user_email: str):
-        """Share a channel with a user. API implementation pending."""
-        raise NotImplementedError("Channel sharing API not yet implemented")
+    def share_channel(self, namespace: str, channel_name: str, user: str, action: str = "share", grant: str = "read"):
+        url = join(self._api_base, "namespaces", namespace, "channels", channel_name, "sharing")
+        data = {"action": action, "user": user}
+        if action == "share":
+            data["grant"] = grant
+
+        print(f"Request url: {url}")
+        print(f"Request data: {data}")
+
+        response = self.post(url, json=data)
+        channel_path = f"{namespace}/{channel_name}"
+        action_verb = "sharing" if action == "share" else "unsharing"
+        return self._manage_response(response, f"{action_verb} channel {channel_path} with {user}", success_codes=[200])

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -633,13 +633,17 @@ class TestRepoCoreChannelsCLI:
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = []
         type(mock_api).account = PropertyMock(side_effect=Exception("No account"))
+        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(
+            channel_path="newchannel", status_code=201
+        )
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["create", "newchannel", "--private"])
 
-        assert result.exit_code == 1
-        assert "Namespace is required" in result.output
-        mock_api.create_namespace_channel.assert_not_called()
+        assert result.exit_code == 0
+        mock_api.create_namespace_channel.assert_called_once_with(
+            channel_name="newchannel", namespace=None, privacy="private"
+        )
 
     def test_channels_create_no_namespaces_with_username(self):
         runner = CliRunner()

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -264,6 +264,31 @@ class TestRepoCoreNamespaceChannel:
         assert result.status_code == 200
         assert result.created is False
 
+    def test_share_channel_role_mapping(self):
+        client = _make_client()
+        mock_response = _mock_response(200, {})
+        client.post = MagicMock(return_value=mock_response)
+
+        client.share_channel("myns", "dev", "testuser", action="share", grant="read")
+        call_args = client.post.call_args
+        assert call_args[1]["json"] == {"action": "share", "user": "testuser", "grant": "read"}
+        assert "grant" in call_args[1]["json"]
+
+        client.share_channel("myns", "dev", "testuser", action="share", grant="write")
+        call_args = client.post.call_args
+        assert call_args[1]["json"] == {"action": "share", "user": "testuser", "grant": "write"}
+        assert "grant" in call_args[1]["json"]
+
+    def test_share_channel_unshare_no_grant(self):
+        client = _make_client()
+        mock_response = _mock_response(200, {})
+        client.post = MagicMock(return_value=mock_response)
+
+        client.share_channel("myns", "dev", "testuser", action="unshare", grant="read")
+        call_args = client.post.call_args
+        assert call_args[1]["json"] == {"action": "unshare", "user": "testuser"}
+        assert "grant" not in call_args[1]["json"]
+
 
 class TestResolveNamespaceAndChannel:
     def test_slash_in_name_extracts_both(self):
@@ -353,17 +378,6 @@ class TestResolveNamespaceAndChannel:
 
         mock_api = MagicMock()
         mock_api.account.get.return_value = {}
-
-        resolved = _resolve_no_namespace(mock_api, "dev")
-
-        assert resolved.namespace is None
-        assert resolved.channel_name == "dev"
-
-    def test_no_namespaces_empty_username(self):
-        from binstar_client.commands._repo_channels import _resolve_no_namespace
-
-        mock_api = MagicMock()
-        mock_api.account.get.return_value = {"username": ""}
 
         resolved = _resolve_no_namespace(mock_api, "dev")
 
@@ -601,23 +615,31 @@ class TestRepoCoreChannelsCLI:
             channel_name="dev", namespace="myns", privacy="private"
         )
 
+    def test_channels_create_privacy_flags_mutually_exclusive(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["create", "myns/dev", "--private", "--public"])
+
+        assert result.exit_code == 1
+        assert "mutually exclusive" in result.output
+        mock_api.create_namespace_channel.assert_not_called()
+
     def test_channels_create_no_namespaces_no_username(self):
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = []
         type(mock_api).account = PropertyMock(side_effect=Exception("No account"))
-        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(
-            channel_path="newchannel", status_code=201
-        )
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["create", "newchannel", "--private"])
 
-        assert result.exit_code == 0
-        mock_api.create_namespace_channel.assert_called_once_with(
-            channel_name="newchannel", namespace=None, privacy="private"
-        )
+        assert result.exit_code == 1
+        assert "Namespace is required" in result.output
+        mock_api.create_namespace_channel.assert_not_called()
 
     def test_channels_create_no_namespaces_with_username(self):
         runner = CliRunner()
@@ -959,6 +981,149 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 1
         assert "No channel specified" in result.output
+
+    def test_share_unshare_option(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["share", "testuser", "--channel", "myorg/dev", "--unshare"])
+
+        assert result.exit_code == 0
+        mock_api.share_channel.assert_called_once_with("myorg", "dev", "testuser", action="unshare", grant="read")
+
+    def test_share_role_not_provided_prompts_user(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
+
+        with (
+            _patch_repo_api(mock_api),
+            patch("binstar_client.commands._repo_channels.select_from_list", return_value="viewer"),
+        ):
+            result = runner.invoke(app, ["share", "testuser", "--channel", "myorg/dev"])
+
+        assert result.exit_code == 0
+        mock_api.share_channel.assert_called_once_with("myorg", "dev", "testuser", action="share", grant="read")
+
+    def test_share_single_channel_success(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["share", "testuser", "--channel", "myorg/dev", "--role", "viewer"])
+
+        assert result.exit_code == 0
+        assert "Success" in result.output
+        assert "myorg/dev" in result.output
+        assert "testuser" in result.output
+        mock_api.share_channel.assert_called_once()
+
+    def test_share_multi_channel_success(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(
+                app, ["share", "testuser", "--channel", "myorg/dev", "--channel", "myorg/staging", "--role", "viewer"]
+            )
+
+        assert result.exit_code == 0
+        assert mock_api.share_channel.call_count == 2
+        mock_api.share_channel.assert_any_call("myorg", "dev", "testuser", action="share", grant="read")
+        mock_api.share_channel.assert_any_call("myorg", "staging", "testuser", action="share", grant="read")
+
+    def test_share_channel_not_namespace_format_prompts_for_namespace_single(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_user_organizations.return_value = [
+            Namespace(name="org-a"),
+            Namespace(name="org-b"),
+        ]
+
+        with (
+            _patch_repo_api(mock_api),
+            patch("binstar_client.commands._repo_channels.select_from_list", return_value="org-a"),
+        ):
+            result = runner.invoke(app, ["share", "testuser", "--channel", "dev", "--role", "viewer"])
+
+        assert result.exit_code == 0
+        mock_api.share_channel.assert_called_once_with("org-a", "dev", "testuser", action="share", grant="read")
+
+    def test_share_channel_not_namespace_format_prompts_for_namespace_multi(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_user_organizations.return_value = [
+            Namespace(name="org-a"),
+            Namespace(name="org-b"),
+        ]
+
+        with (
+            _patch_repo_api(mock_api),
+            patch(
+                "binstar_client.commands._repo_channels.select_from_list",
+                side_effect=["org-a", "org-b"],
+            ),
+        ):
+            result = runner.invoke(
+                app, ["share", "testuser", "--channel", "dev", "--channel", "staging", "--role", "viewer"]
+            )
+
+        assert result.exit_code == 0
+        assert mock_api.share_channel.call_count == 2
+        mock_api.share_channel.assert_any_call("org-a", "dev", "testuser", action="share", grant="read")
+        mock_api.share_channel.assert_any_call("org-b", "staging", "testuser", action="share", grant="read")
+
+    def test_share_namespace_option_provides_namespace(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(
+                app,
+                [
+                    "share",
+                    "testuser",
+                    "--channel",
+                    "dev",
+                    "--channel",
+                    "staging",
+                    "--namespace",
+                    "myorg",
+                    "--role",
+                    "viewer",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert mock_api.share_channel.call_count == 2
+        mock_api.share_channel.assert_any_call("myorg", "dev", "testuser", action="share", grant="read")
+        mock_api.share_channel.assert_any_call("myorg", "staging", "testuser", action="share", grant="read")
+        mock_api.list_user_organizations.assert_not_called()
+
+    def test_share_namespace_with_slash_format_throws_ambiguous(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(
+                app, ["share", "testuser", "--channel", "org-a/dev", "--namespace", "org-b", "--role", "viewer"]
+            )
+
+        assert result.exit_code == 1
+        assert "Ambiguous" in result.output
+        mock_api.share_channel.assert_not_called()
 
     def test_upload_404_with_deprecated_flag_shows_label_hint(self):
         runner = CliRunner()

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -998,16 +998,13 @@ class TestRepoCoreChannelsCLI:
         assert result.exit_code == 0
         mock_api.share_channel.assert_called_once_with("myorg", "dev", "testuser", action="unshare", grant="read")
 
-    def test_share_role_not_provided_prompts_user(self):
+    def test_share_role_defaults_to_viewer(self):
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
 
-        with (
-            _patch_repo_api(mock_api),
-            patch("binstar_client.commands._repo_channels.select_from_list", return_value="viewer"),
-        ):
+        with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["share", "testuser", "--channel", "myorg/dev"])
 
         assert result.exit_code == 0


### PR DESCRIPTION
- adds `share` subcommand of `channel` for channel sharing
- made `_manage_response` more generalizable to all client methods 