### PR TITLE
PREX-2239 - fix -n commands for notices and increase message limit

### DIFF
--- a/binstar_client/commands/_channel_notices.py
+++ b/binstar_client/commands/_channel_notices.py
@@ -134,8 +134,29 @@ def resolve_notice_owner(
     raise errors.UserError('channel or --namespace is required')
 
 
+def _coerce_notice_id_args(
+    channel: Optional[str],
+    notice_id: Optional[str],
+    namespace: Optional[str],
+) -> tuple[Optional[str], Optional[str]]:
+    """When --namespace is set, a lone positional UUID is the notice_id, not channel."""
+    if namespace and channel and not notice_id:
+        try:
+            uuid.UUID(channel)
+        except ValueError:
+            return channel, notice_id
+        return None, channel
+    return channel, notice_id
+
+
 def _is_interactive() -> bool:
     return sys.stdin.isatty()
+
+
+def _prompt_input(label: str) -> str:
+    """Prompt with a bold label, matching select_from_list header styling."""
+    text = label.rstrip(': ').rstrip()
+    return console.input(f'[bold]{text}:[/bold] ').strip()
 
 
 def validate_notice_id(notice_id: str) -> str:
@@ -169,7 +190,7 @@ def prompt_message(value: Optional[str] = None, *, interactive: bool) -> str:
     if not interactive:
         raise errors.UserError('message is required (non-interactive mode)')
     while True:
-        message = input('Message: ').strip()
+        message = _prompt_input('Message')
         try:
             return validate_message(message)
         except errors.UserError as err:
@@ -189,6 +210,13 @@ def prompt_notice_level(*, optional: bool = False) -> Optional[str]:
         level = select_from_list('Level (or skip):', [LEVEL_SKIP_CHOICE, *NOTICE_LEVELS])
         return None if level == LEVEL_SKIP_CHOICE else level
     return select_from_list('Level:', list(NOTICE_LEVELS))
+
+
+def prompt_update_status() -> Optional[str]:
+    status = select_from_list('Status (or skip):', [LEVEL_SKIP_CHOICE, *UPDATE_STATUS_VALUES])
+    if status == LEVEL_SKIP_CHOICE:
+        return None
+    return validate_update_status(status)
 
 
 def resolve_level(value: Optional[str] = None, *, interactive: bool) -> str:
@@ -243,7 +271,7 @@ def parse_expiry_input(value: str) -> str:
 def prompt_expiry_interactive() -> str:
     blank_attempts = 0
     while True:
-        value = input(EXPIRY_PROMPT).strip()
+        value = _prompt_input(EXPIRY_PROMPT.rstrip(': '))
         if not value:
             blank_attempts += 1
             if blank_attempts >= MAX_BLANK_EXPIRY_ATTEMPTS:
@@ -458,16 +486,16 @@ def do_update(
             raise errors.UserError(
                 'At least one of --message, --level, --expires-at, --expires-after, or --status is required'
             )
-        optional_message = input('Message (leave blank to skip): ').strip()
+        optional_message = _prompt_input('Message (leave blank to skip)')
         if optional_message:
             fields['message'] = validate_message(optional_message)
         optional_level = prompt_notice_level(optional=True)
         if optional_level:
             fields['level'] = optional_level
-        optional_status = input(f'Status ({"/".join(UPDATE_STATUS_VALUES)}, blank to skip): ').strip().lower()
+        optional_status = prompt_update_status()
         if optional_status:
-            fields['status'] = validate_update_status(optional_status)
-        optional_expires = input(EXPIRY_UPDATE_PROMPT).strip()
+            fields['status'] = optional_status
+        optional_expires = _prompt_input(EXPIRY_UPDATE_PROMPT.rstrip(': '))
         if optional_expires:
             fields['expires_at'] = parse_expiry_input(optional_expires)
 
@@ -525,10 +553,17 @@ def _parse_notice_action(action: str) -> NoticeAction:
 def main(args: argparse.Namespace) -> None:
     """Dispatch channel notice subcommands."""
     action = _parse_notice_action(args.notice_action)
+    channel, notice_id = _coerce_notice_id_args(
+        getattr(args, 'channel', None),
+        getattr(args, 'notice_id', None),
+        getattr(args, 'namespace', None),
+    )
+    args.channel = channel
+    args.notice_id = notice_id
     api = get_server_api(args.token, args.site)
 
     channel = resolve_notice_owner(
-        getattr(args, 'channel', None),
+        channel,
         getattr(args, 'namespace', None),
     )
 
@@ -686,6 +721,7 @@ def mount_notice_subcommand(parent_app: typer.Typer) -> None:
     ) -> None:
         args = _ctx_args(ctx)
         args.notice_action = action.value
+        channel, notice_id = _coerce_notice_id_args(channel, notice_id, namespace)
         args.channel = channel
         args.notice_id = notice_id
         args.namespace = namespace

--- a/binstar_client/commands/_channel_notices.py
+++ b/binstar_client/commands/_channel_notices.py
@@ -44,7 +44,7 @@ EXPIRY_PROMPT = 'Expiry (days e.g. 30, or ISO 8601 e.g. 2026-09-16T12:00:00Z): '
 EXPIRY_UPDATE_PROMPT = 'Expiry (days e.g. 30, or ISO 8601 e.g. 2026-09-16T12:00:00Z; blank to keep current): '
 DEFAULT_INTERACTIVE_EXPIRY_DAYS = 30
 MAX_BLANK_EXPIRY_ATTEMPTS = 3
-MESSAGE_MAX_LEN = 256
+MESSAGE_MAX_LEN = 600
 MESSAGE_HELP = f'Text to show in the notice (max {MESSAGE_MAX_LEN} characters)'
 MESSAGE_UPDATE_HELP = f'Updated text to show in the notice (max {MESSAGE_MAX_LEN} characters)'
 EXPIRES_AT_HELP = 'Expiry time in ISO 8601 format (e.g. 2026-09-16T12:00:00Z)'
@@ -159,6 +159,13 @@ def _prompt_input(label: str) -> str:
     return console.input(f'[bold]{text}:[/bold] ').strip()
 
 
+def _show_validation_error(message: str) -> None:
+    """Show an interactive validation error with clear visual separation."""
+    console.print('-------')
+    console.print(message)
+    console.print('-------')
+
+
 def validate_notice_id(notice_id: str) -> str:
     try:
         uuid.UUID(notice_id)
@@ -178,9 +185,9 @@ def validate_update_status(status: str) -> str:
 def validate_message(message: str) -> str:
     message = message.strip()
     if not message:
-        raise errors.UserError('message is required')
+        raise errors.UserError('Message is required')
     if len(message) > MESSAGE_MAX_LEN:
-        raise errors.UserError(f'message must be at most {MESSAGE_MAX_LEN} characters')
+        raise errors.UserError(f'Message must be at most {MESSAGE_MAX_LEN} characters')
     return message
 
 
@@ -194,7 +201,7 @@ def prompt_message(value: Optional[str] = None, *, interactive: bool) -> str:
         try:
             return validate_message(message)
         except errors.UserError as err:
-            logger.warning('%s', err)
+            _show_validation_error(str(err))
 
 
 @overload
@@ -282,14 +289,14 @@ def prompt_expiry_interactive() -> str:
                     return expires_at_from_days(DEFAULT_INTERACTIVE_EXPIRY_DAYS)
                 blank_attempts = 0
             else:
-                logger.warning('expiry is required')
+                _show_validation_error('Expiry is required')
             continue
 
         blank_attempts = 0
         try:
             return parse_expiry_input(value)
         except errors.UserError as err:
-            logger.warning('%s', err)
+            _show_validation_error(str(err))
 
 
 def resolve_expires_at(

--- a/doc/channel_notices.md
+++ b/doc/channel_notices.md
@@ -101,7 +101,7 @@ anaconda channel notice create mychannel \
 
 | Option | Description |
 |--------|-------------|
-| `--message` | Notice text (required, max 256 characters) |
+| `--message` | Notice text (required, max 600 characters) |
 | `--level` | `info` (default), `warning`, or `critical` |
 | `--expires-after DAYS` | Expire N days from now |
 | `--expires-at` | Exact expiry (ISO 8601, e.g. `2026-09-16T12:00:00+00:00`) |

--- a/doc/channel_notices.md
+++ b/doc/channel_notices.md
@@ -14,29 +14,32 @@ Notices are nested under the `channel` command (same group as repocore channel m
 ANACONDA_CLIENT_FORCE_STANDALONE=1 binstar channel notice <subcommand> ...
 ```
 
-## Channel argument
+## Channel / namespace
 
-`<channel>` is the **owner login** (user or organization account), for example `user` or `myorg`. It is not a repocore namespace path such as `myorg/dev`.
+The **owner login** identifies whose notices you manage (user or organization account), for example `myorg` or `myuser`. This is not a repocore path such as `myorg/dev`.
 
-Pass the owner login as a positional argument:
+Specify the owner in one of two ways:
 
-```bash
-anaconda channel notice list myorg
-```
+| Form | Example |
+|------|---------|
+| Positional `<channel>` | `anaconda channel notice list myorg` |
+| `--namespace` / `-n` | `anaconda channel notice list --namespace myorg` |
 
-Or use `-n` / `--namespace` instead of the positional channel:
+`-n` is a short alias for `--namespace`; both are equivalent. Examples below use `--namespace`; substitute `-n` anywhere it appears.
 
-```bash
-anaconda channel notice list --namespace myorg
-```
-
-For lifecycle commands (`get`, `update`, `publish`, `archive`, `delete`), you can pass the notice UUID as the only positional argument when using `--namespace`:
+For commands that take a notice UUID (`get`, `update`, `publish`, `archive`, `delete`), you can combine `--namespace` with the UUID as the only positional argument:
 
 ```bash
-anaconda channel notice archive -n myorg 550e8400-e29b-41d4-a716-446655440000
+anaconda channel notice archive --namespace myorg 550e8400-e29b-41d4-a716-446655440000
 ```
 
-Either a positional channel or `--namespace` is required.
+Or pass owner and UUID as two positionals (no namespace flag):
+
+```bash
+anaconda channel notice archive myorg 550e8400-e29b-41d4-a716-446655440000
+```
+
+Either a positional owner or `--namespace` / `-n` is required.
 
 ## Notice IDs
 

--- a/doc/channel_notices.md
+++ b/doc/channel_notices.md
@@ -30,6 +30,12 @@ Or use `-n` / `--namespace` instead of the positional channel:
 anaconda channel notice list --namespace myorg
 ```
 
+For lifecycle commands (`get`, `update`, `publish`, `archive`, `delete`), you can pass the notice UUID as the only positional argument when using `--namespace`:
+
+```bash
+anaconda channel notice archive -n myorg 550e8400-e29b-41d4-a716-446655440000
+```
+
 Either a positional channel or `--namespace` is required.
 
 ## Notice IDs

--- a/tests/test_notices.py
+++ b/tests/test_notices.py
@@ -482,7 +482,7 @@ class TestNotices(CLITestCase):
                 ]
             )
 
-        self.assertIn('message is required', str(ctx.exception))
+        self.assertIn('Message is required', str(ctx.exception))
 
     @urlpatch
     def test_create_notice_rejects_message_over_max_length(self, urls):
@@ -495,13 +495,13 @@ class TestNotices(CLITestCase):
                     'create',
                     'myteam',
                     '--message',
-                    'x' * 257,
+                    'x' * 601,
                     '--expires-after',
                     '7',
                 ]
             )
 
-        self.assertIn('message must be at most 256 characters', str(ctx.exception))
+        self.assertIn('Message must be at most 600 characters', str(ctx.exception))
 
     @urlpatch
     @unittest.mock.patch('binstar_client.commands._channel_notices.bool_input', return_value=False)

--- a/tests/test_notices.py
+++ b/tests/test_notices.py
@@ -205,7 +205,7 @@ class TestNotices(CLITestCase):
     @urlpatch
     @unittest.mock.patch('binstar_client.commands._channel_notices.bool_input', return_value=False)
     @unittest.mock.patch('binstar_client.commands._channel_notices._is_interactive', return_value=True)
-    @unittest.mock.patch('binstar_client.commands._channel_notices.input')
+    @unittest.mock.patch('binstar_client.commands._channel_notices._prompt_input')
     def test_create_notice_interactive(self, urls, input_mock, _is_interactive_mock, _bool_input_mock):
         input_mock.side_effect = [
             'interactive message',
@@ -316,6 +316,52 @@ class TestNotices(CLITestCase):
 
         urls.assertAllCalled()
         self.assertIn(f"Notice '{NOTICE_UUID}' archived successfully", self.stream.getvalue())
+
+    @urlpatch
+    @unittest.mock.patch('binstar_client.commands._channel_notices.bool_input', return_value=True)
+    def test_archive_with_namespace_and_notice_id_only(self, urls, _bool_input_mock):
+        archive = urls.register(
+            method='POST',
+            path=f'/myorg/notices/{NOTICE_UUID}/archive',
+            content={'notice_id': NOTICE_UUID, 'status': 'archived'},
+        )
+
+        with _patch_notice_console_print():
+            main(['--show-traceback', 'channel', 'notice', 'archive', '-n', 'myorg', NOTICE_UUID, '--force'])
+
+        urls.assertAllCalled()
+        self.assertIn(f'/myorg/notices/{NOTICE_UUID}/archive', archive.req.url)
+        self.assertIn(f"Notice '{NOTICE_UUID}' archived successfully", self.stream.getvalue())
+
+    @urlpatch
+    @unittest.mock.patch('binstar_client.commands._channel_notices.bool_input', return_value=True)
+    def test_publish_with_namespace_and_notice_id_only(self, urls, _bool_input_mock):
+        publish = urls.register(
+            method='POST',
+            path=f'/myorg/notices/{NOTICE_UUID}/publish',
+            content={'notice_id': NOTICE_UUID, 'status': 'published'},
+        )
+
+        with _patch_notice_console_print():
+            main(['--show-traceback', 'channel', 'notice', 'publish', '-n', 'myorg', NOTICE_UUID, '--force'])
+
+        urls.assertAllCalled()
+        self.assertIn(f'/myorg/notices/{NOTICE_UUID}/publish', publish.req.url)
+        self.assertIn(f"Notice '{NOTICE_UUID}' published successfully", self.stream.getvalue())
+
+    def test_coerce_notice_id_args_with_namespace(self):
+        from binstar_client.commands._channel_notices import _coerce_notice_id_args
+
+        channel, notice_id = _coerce_notice_id_args(NOTICE_UUID, None, 'myorg')
+        self.assertIsNone(channel)
+        self.assertEqual(notice_id, NOTICE_UUID)
+
+    def test_coerce_notice_id_args_without_namespace(self):
+        from binstar_client.commands._channel_notices import _coerce_notice_id_args
+
+        channel, notice_id = _coerce_notice_id_args('myorg', NOTICE_UUID, None)
+        self.assertEqual(channel, 'myorg')
+        self.assertEqual(notice_id, NOTICE_UUID)
 
     @urlpatch
     def test_archive_notice_force(self, urls):
@@ -460,7 +506,7 @@ class TestNotices(CLITestCase):
     @urlpatch
     @unittest.mock.patch('binstar_client.commands._channel_notices.bool_input', return_value=False)
     @unittest.mock.patch('binstar_client.commands._channel_notices._is_interactive', return_value=True)
-    @unittest.mock.patch('binstar_client.commands._channel_notices.input')
+    @unittest.mock.patch('binstar_client.commands._channel_notices._prompt_input')
     @freezegun.freeze_time('2026-06-01T12:00:00Z')
     def test_create_notice_interactive_days(self, urls, input_mock, _is_interactive_mock, _bool_mock):
         input_mock.side_effect = ['hello', '30']
@@ -480,7 +526,7 @@ class TestNotices(CLITestCase):
     @urlpatch
     @unittest.mock.patch('binstar_client.commands._channel_notices.bool_input', side_effect=[True, False])
     @unittest.mock.patch('binstar_client.commands._channel_notices._is_interactive', return_value=True)
-    @unittest.mock.patch('binstar_client.commands._channel_notices.input')
+    @unittest.mock.patch('binstar_client.commands._channel_notices._prompt_input')
     @freezegun.freeze_time('2026-06-01T12:00:00Z')
     def test_create_notice_interactive_blank_then_accept_default(
         self, urls, input_mock, _is_interactive_mock, _bool_mock
@@ -502,7 +548,7 @@ class TestNotices(CLITestCase):
     @urlpatch
     @unittest.mock.patch('binstar_client.commands._channel_notices.bool_input', side_effect=[False, False])
     @unittest.mock.patch('binstar_client.commands._channel_notices._is_interactive', return_value=True)
-    @unittest.mock.patch('binstar_client.commands._channel_notices.input')
+    @unittest.mock.patch('binstar_client.commands._channel_notices._prompt_input')
     @freezegun.freeze_time('2026-06-01T12:00:00Z')
     def test_create_notice_interactive_blank_then_decline_default(
         self, urls, input_mock, _is_interactive_mock, _bool_mock
@@ -524,7 +570,7 @@ class TestNotices(CLITestCase):
     @urlpatch
     @unittest.mock.patch('binstar_client.commands._channel_notices.bool_input', return_value=True)
     @unittest.mock.patch('binstar_client.commands._channel_notices._is_interactive', return_value=True)
-    @unittest.mock.patch('binstar_client.commands._channel_notices.input')
+    @unittest.mock.patch('binstar_client.commands._channel_notices._prompt_input')
     def test_create_notice_interactive_publish_yes(self, urls, input_mock, _is_interactive_mock, _bool_mock):
         input_mock.side_effect = ['hello', '2026-09-16T12:00:00+00:00']
         urls.register(
@@ -546,9 +592,9 @@ class TestNotices(CLITestCase):
 
     @urlpatch
     @unittest.mock.patch('binstar_client.commands._channel_notices._is_interactive', return_value=True)
-    @unittest.mock.patch('binstar_client.commands._channel_notices.input')
+    @unittest.mock.patch('binstar_client.commands._channel_notices._prompt_input')
     def test_update_interactive_keeps_expiry_when_blank(self, urls, input_mock, _is_interactive_mock):
-        input_mock.side_effect = ['updated message', '', '']
+        input_mock.side_effect = ['updated message', '']
         update = urls.register(
             method='PATCH',
             path=f'/myteam/notices/{NOTICE_UUID}',
@@ -564,10 +610,10 @@ class TestNotices(CLITestCase):
 
     @urlpatch
     @unittest.mock.patch('binstar_client.commands._channel_notices._is_interactive', return_value=True)
-    @unittest.mock.patch('binstar_client.commands._channel_notices.input')
+    @unittest.mock.patch('binstar_client.commands._channel_notices._prompt_input')
     @freezegun.freeze_time('2026-06-01T12:00:00Z')
     def test_update_interactive_days(self, urls, input_mock, _is_interactive_mock):
-        input_mock.side_effect = ['', '', '14']
+        input_mock.side_effect = ['', '14']
         update = urls.register(
             method='PATCH',
             path=f'/myteam/notices/{NOTICE_UUID}',


### PR DESCRIPTION
## Summary
https://anaconda.atlassian.net/browse/PREX-2239
https://anaconda.atlassian.net/browse/PREX-2242

Fixes --namespace / -n usage for notice lifecycle commands, improves interactive create/update prompts, and aligns message validation with the new 600-character limit.

### `-n` + notice ID parsing

Lifecycle commands (`get`, `update`, `publish`, `archive`, `delete`) accept `-n` / `--namespace`, but Typer was binding a lone UUID to the first positional (`channel`) instead of `notice_id`:

```bash
# Before: Missing argument 'NOTICE_ID'
anaconda channel notice archive -n spai-org <uuid>

# After: works
anaconda channel notice archive -n spai-org <uuid>
```

Positional owner + UUID still works unchanged:

```bash
anaconda channel notice archive spai-org <uuid>
```

Added `_coerce_notice_id_args()` so when `--namespace` is set and the only positional is a UUID, it is treated as `notice_id`.

### Interactive UX

- **Update:** status uses `select_from_list` (like level), with `(skip)`, `published`, `archived`
- **Create/update:** message and expiry prompts use bold Rich labels via `_prompt_input()`, matching level/status selectors

### Message validation
- Increased message limit from 256 → 600 characters (MESSAGE_MAX_LEN)
- Capitalized validation errors: Message is required, Message must be at most 600 characters
- Updated --message help text and doc/channel_notices.md
- Message Validation error screenshot
<img width="1335" height="231" alt="image" src="https://github.com/user-attachments/assets/881b08ba-92e0-401b-a292-89fbd5752641" />


### Docs & tests
- Documented -n myorg <notice-uuid> pattern in doc/channel_notices.md
- Added tests for namespace + UUID coercion, archive/publish with -n, interactive prompt updates, and 600-character validation
