### PR TITLE
HUB-3433_tweak_channel_creation_to_handle_200_201

### DIFF
--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -295,7 +295,10 @@ def create_command(
     response = api.create_namespace_channel(
         channel_name=resolved.channel_name, namespace=resolved.namespace, privacy=privacy
     )
-    console.print(f"[green]Success![/green] Channel '[cyan]{response['channel_path']}[/cyan]' created ({privacy}).")
+    if response.created:
+        console.print(f"[green]Success![/green] Channel '[cyan]{response.channel_path}[/cyan]' created ({privacy}).")
+    else:
+        console.print(f"Channel '[cyan]{response.channel_path}[/cyan]' already exists.")
 
 
 @app.command(name="remove", help="Remove a channel")

--- a/binstar_client/repocore/__init__.py
+++ b/binstar_client/repocore/__init__.py
@@ -3,6 +3,7 @@
 from binstar_client.repocore.client import REPO_API_PATH, AUTH_API_PATH, RepoCoreClient
 from binstar_client.repocore.models import (
     Channel,
+    ChannelCreationResponse,
     Namespace,
     NamespaceChannel,
     ResolvedChannel,
@@ -13,6 +14,7 @@ __all__ = [
     "AUTH_API_PATH",
     "RepoCoreClient",
     "Channel",
+    "ChannelCreationResponse",
     "Namespace",
     "NamespaceChannel",
     "ResolvedChannel",

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -173,7 +173,9 @@ class RepoCoreClient(BaseClient):
         data = self._manage_response(response, f"getting channel {channel} subchannels")
         return [Channel(**item) for item in data.get("items", [])]
 
-    def create_namespace_channel(self, channel_name: str, namespace: Optional[str] = None, privacy: str = "private") -> ChannelCreationResponse:
+    def create_namespace_channel(
+        self, channel_name: str, namespace: Optional[str] = None, privacy: str = "private"
+    ) -> ChannelCreationResponse:
         url = join(self._api_base, "namespace-channels")
         data = {"channel_name": channel_name, "privacy": privacy}
 

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -12,6 +12,7 @@ from anaconda_auth.client import BaseClient
 from binstar_client.repocore.errors import InvalidName, RepoCoreError, Unauthorized
 from binstar_client.repocore.models import (
     Channel,
+    ChannelCreationResponse,
     Namespace,
     NamespaceChannel,
 )
@@ -172,14 +173,15 @@ class RepoCoreClient(BaseClient):
         data = self._manage_response(response, f"getting channel {channel} subchannels")
         return [Channel(**item) for item in data.get("items", [])]
 
-    def create_namespace_channel(self, channel_name: str, namespace: Optional[str] = None, privacy: str = "private"):
+    def create_namespace_channel(self, channel_name: str, namespace: Optional[str] = None, privacy: str = "private") -> ChannelCreationResponse:
         url = join(self._api_base, "namespace-channels")
         data = {"channel_name": channel_name, "privacy": privacy}
 
         if namespace:
             data["namespace"] = namespace
         response = self.post(url, json=data)
-        return self._manage_response(response, f"creating namespace channel {channel_name}", success_codes=[200, 201])
+        result = self._manage_response(response, f"creating namespace channel {channel_name}", success_codes=[200, 201])
+        return ChannelCreationResponse(status_code=response.status_code, **result)
 
     def upload_file(self, filepath: str, channel: str, package_type: str):
         try:

--- a/binstar_client/repocore/models.py
+++ b/binstar_client/repocore/models.py
@@ -52,6 +52,17 @@ class NamespaceChannel(BaseModel):
         return [o for o in v if o]
 
 
+class ChannelCreationResponse(BaseModel):
+    """Response from creating a namespace channel."""
+
+    channel_path: str
+    status_code: int
+
+    @property
+    def created(self) -> bool:
+        return self.status_code == 201
+
+
 class ResolvedChannel(BaseModel):
     """Resolved namespace and channel name."""
 

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -7,6 +7,7 @@ from typer.testing import CliRunner
 
 from binstar_client.repocore import (
     Channel,
+    ChannelCreationResponse,
     Namespace,
     NamespaceChannel,
     RepoCoreClient,
@@ -234,7 +235,9 @@ class TestRepoCoreNamespaceChannel:
         client.post = MagicMock(return_value=mock_response)
 
         result = client.create_namespace_channel("dev", namespace="myns", privacy="public")
-        assert result == {"channel_path": "myns/dev"}
+        assert result.channel_path == "myns/dev"
+        assert result.status_code == 201
+        assert result.created is True
         call_args = client.post.call_args
         assert "namespace-channels" in call_args[0][0]
         assert call_args[1]["json"] == {"channel_name": "dev", "namespace": "myns", "privacy": "public"}
@@ -245,9 +248,21 @@ class TestRepoCoreNamespaceChannel:
         client.post = MagicMock(return_value=mock_response)
 
         result = client.create_namespace_channel("dev")
-        assert result == {"channel_path": "dev/dev"}
+        assert result.channel_path == "dev/dev"
+        assert result.status_code == 201
+        assert result.created is True
         call_args = client.post.call_args
         assert call_args[1]["json"] == {"channel_name": "dev", "privacy": "private"}
+
+    def test_create_namespace_channel_already_exists(self):
+        client = _make_client()
+        mock_response = _mock_response(200, {"channel_path": "myns/dev"})
+        client.post = MagicMock(return_value=mock_response)
+
+        result = client.create_namespace_channel("dev", namespace="myns")
+        assert result.channel_path == "myns/dev"
+        assert result.status_code == 200
+        assert result.created is False
 
 
 class TestResolveNamespaceAndChannel:
@@ -484,7 +499,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.create_namespace_channel.return_value = {"channel_path": "myns/dev"}
+        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(channel_path="myns/dev", status_code=201)
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["create", "myns/dev", "--public"])
@@ -499,7 +514,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.create_namespace_channel.return_value = {"channel_path": "myns/dev"}
+        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(channel_path="myns/dev", status_code=201)
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["create", "dev", "--namespace", "myns", "--public"])
@@ -515,7 +530,7 @@ class TestRepoCoreChannelsCLI:
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = []
         type(mock_api).account = PropertyMock(return_value={"user": {"username": "testuser"}})
-        mock_api.create_namespace_channel.return_value = {"channel_path": "testuser/newchannel"}
+        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(channel_path="testuser/newchannel", status_code=201)
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["create", "newchannel", "--private"], input="y\n")
@@ -530,7 +545,7 @@ class TestRepoCoreChannelsCLI:
         app = _get_channels_app()
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
-        mock_api.create_namespace_channel.return_value = {"channel_path": "myorg/dev"}
+        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(channel_path="myorg/dev", status_code=201)
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["create", "dev", "--public"])
@@ -544,7 +559,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.create_namespace_channel.return_value = {"channel_path": "myns/dev"}
+        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(channel_path="myns/dev", status_code=201)
 
         with (
             _patch_repo_api(mock_api),
@@ -561,7 +576,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.create_namespace_channel.return_value = {"channel_path": "myns/dev"}
+        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(channel_path="myns/dev", status_code=201)
 
         with (
             _patch_repo_api(mock_api),
@@ -580,7 +595,7 @@ class TestRepoCoreChannelsCLI:
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = []
         type(mock_api).account = PropertyMock(side_effect=Exception("No account"))
-        mock_api.create_namespace_channel.return_value = {"channel_path": "newchannel"}
+        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(channel_path="newchannel", status_code=201)
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["create", "newchannel", "--private"])
@@ -596,7 +611,7 @@ class TestRepoCoreChannelsCLI:
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = []
         type(mock_api).account = PropertyMock(return_value={"user": {"username": "testuser"}})
-        mock_api.create_namespace_channel.return_value = {"channel_path": "testuser/newchannel"}
+        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(channel_path="testuser/newchannel", status_code=201)
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["create", "newchannel", "--private"], input="y\n")

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -499,7 +499,9 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(channel_path="myns/dev", status_code=201)
+        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(
+            channel_path="myns/dev", status_code=201
+        )
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["create", "myns/dev", "--public"])
@@ -514,7 +516,9 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(channel_path="myns/dev", status_code=201)
+        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(
+            channel_path="myns/dev", status_code=201
+        )
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["create", "dev", "--namespace", "myns", "--public"])
@@ -530,7 +534,9 @@ class TestRepoCoreChannelsCLI:
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = []
         type(mock_api).account = PropertyMock(return_value={"user": {"username": "testuser"}})
-        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(channel_path="testuser/newchannel", status_code=201)
+        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(
+            channel_path="testuser/newchannel", status_code=201
+        )
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["create", "newchannel", "--private"], input="y\n")
@@ -545,7 +551,9 @@ class TestRepoCoreChannelsCLI:
         app = _get_channels_app()
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
-        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(channel_path="myorg/dev", status_code=201)
+        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(
+            channel_path="myorg/dev", status_code=201
+        )
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["create", "dev", "--public"])
@@ -559,7 +567,9 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(channel_path="myns/dev", status_code=201)
+        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(
+            channel_path="myns/dev", status_code=201
+        )
 
         with (
             _patch_repo_api(mock_api),
@@ -576,7 +586,9 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(channel_path="myns/dev", status_code=201)
+        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(
+            channel_path="myns/dev", status_code=201
+        )
 
         with (
             _patch_repo_api(mock_api),
@@ -595,7 +607,9 @@ class TestRepoCoreChannelsCLI:
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = []
         type(mock_api).account = PropertyMock(side_effect=Exception("No account"))
-        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(channel_path="newchannel", status_code=201)
+        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(
+            channel_path="newchannel", status_code=201
+        )
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["create", "newchannel", "--private"])
@@ -611,7 +625,9 @@ class TestRepoCoreChannelsCLI:
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = []
         type(mock_api).account = PropertyMock(return_value={"user": {"username": "testuser"}})
-        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(channel_path="testuser/newchannel", status_code=201)
+        mock_api.create_namespace_channel.return_value = ChannelCreationResponse(
+            channel_path="testuser/newchannel", status_code=201
+        )
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["create", "newchannel", "--private"], input="y\n")


### PR DESCRIPTION
Right now we return a successful creation message regardless of the status code. For repocore channel creation, a 201 indicates a new channel was created. Repeating the action will then return a 200--nothing went wrong, but the channel already exists.

This PR just separates the two status codes so the user is better informed when they attempt to create a channel.