### PR TITLE
PREX-2453 - parse id instead of notice_id

### DIFF
--- a/binstar_client/commands/_channel_notices.py
+++ b/binstar_client/commands/_channel_notices.py
@@ -115,7 +115,7 @@ NOTICE_ID_ACTIONS = (
     (NoticeAction.PUBLISH.value, NOTICE_ACTION_HELP[NoticeAction.PUBLISH]),
     (NoticeAction.ARCHIVE.value, NOTICE_ACTION_HELP[NoticeAction.ARCHIVE]),
 )
-NOTICE_ID_HELP = f'Notice UUID (from create output or run: {NOTICE_CLI_PREFIX} {NoticeAction.LIST.value} <channel>)'
+NOTICE_ID_HELP = f'Notice ID (UUID from create output or run: {NOTICE_CLI_PREFIX} {NoticeAction.LIST.value} <channel>)'
 NOTICE_ID_ACTIONS_REQUIRING_UUID = (
     NoticeAction.GET,
     NoticeAction.UPDATE,
@@ -144,7 +144,7 @@ def _coerce_notice_id_args(
     notice_id: Optional[str],
     namespace: Optional[str],
 ) -> tuple[Optional[str], Optional[str]]:
-    """When --namespace is set, a lone positional UUID is the notice_id, not channel."""
+    """When --namespace is set, a lone positional UUID is the Notice ID, not channel."""
     if namespace and channel and not notice_id:
         try:
             uuid.UUID(channel)
@@ -177,6 +177,12 @@ def _format_list_cell(value: object) -> str:
     return escape(_sanitize_notice_text(str(value or '')))
 
 
+def _notice_id_from_payload(payload: Dict[str, Any], default: str = '') -> str:
+    """Read notice UUID from API payload field ``id``."""
+    value = payload.get('id', default)
+    return str(value) if value else ''
+
+
 def _show_validation_error(message: str) -> None:
     """Show an interactive validation error with clear visual separation."""
     console.print('-------')
@@ -188,7 +194,7 @@ def validate_notice_id(notice_id: str) -> str:
     try:
         uuid.UUID(notice_id)
     except ValueError as err:
-        raise errors.UserError('notice_id must be a valid UUID') from err
+        raise errors.UserError('Notice ID must be a valid UUID') from err
     return notice_id
 
 
@@ -347,14 +353,14 @@ def format_list_command(channel: str) -> str:
 def print_missing_notice_id_hint(channel: Optional[str] = None) -> None:
     channel_arg = channel or '<channel>'
     list_cmd = format_list_command(channel_arg)
-    console.print("[bold red]Error:[/bold red] Missing argument 'NOTICE_ID'.")
-    console.print(f'Note: Find notice IDs with: [cyan]{list_cmd}[/cyan]')
+    console.print("[bold red]Error:[/bold red] Missing argument 'Notice ID'.")
+    console.print(f'Note: Find Notice IDs with: [cyan]{list_cmd}[/cyan]')
 
 
 def require_notice_id(notice_id: Optional[str], channel: Optional[str] = None) -> str:
     if not notice_id:
         print_missing_notice_id_hint(channel)
-        raise errors.UserError("Missing argument 'NOTICE_ID'.")
+        raise errors.UserError("Missing argument 'Notice ID'.")
     return notice_id
 
 
@@ -405,7 +411,7 @@ def show_admin_notices(items: list, channel: str) -> None:
 
     for item in items:
         table.add_row(
-            _format_list_cell(item.get('notice_id', '')),
+            _format_list_cell(_notice_id_from_payload(item)),
             _format_list_cell(item.get('status', '')),
             _format_list_cell(item.get('level', '')),
             _format_list_cell(item.get('message', '')),
@@ -416,7 +422,7 @@ def show_admin_notices(items: list, channel: str) -> None:
 
 
 def show_notice_detail(notice: Dict[str, Any], verbose: bool = False) -> None:
-    notice_id = notice.get('notice_id', notice.get('id', ''))
+    notice_id = _notice_id_from_payload(notice)
 
     if verbose:
         console.print(json.dumps(notice, indent=2))
@@ -479,12 +485,12 @@ def do_create(
     expires_at = resolve_expires_at(expires_at, expires_after, interactive=interactive)
 
     result = api.create_notice(channel, message, level, expires_at)
-    created_id = result.get('notice_id')
+    created_id = _notice_id_from_payload(result)
     if not created_id:
-        raise errors.UserError('API did not return a notice_id')
+        raise errors.UserError('API did not return a Notice ID')
     status = result.get('status', NoticeStatus.DRAFT.value)
     console.print(f"Notice '{created_id}' created successfully ({status}).")
-    console.print(f'Find notice IDs with: {format_list_command(channel)}')
+    console.print(f'Find Notice IDs with: {format_list_command(channel)}')
     offer_publish_after_create(api, channel, created_id, status, interactive=interactive)
 
 
@@ -536,7 +542,7 @@ def do_update(
         raise errors.UserError('At least one field is required to update')
 
     result = api.update_notice(channel, notice_id, **fields)
-    updated_id = result.get('notice_id', notice_id)
+    updated_id = _notice_id_from_payload(result, notice_id)
     console.print(f"Notice '{updated_id}' updated successfully.")
 
 
@@ -559,7 +565,7 @@ def do_publish(api, channel: str, notice_id: str, force: bool = False) -> None:
             return
 
     result = api.publish_notice(channel, notice_id)
-    published_id = result.get('notice_id', notice_id)
+    published_id = _notice_id_from_payload(result, notice_id)
     console.print(f"Notice '{published_id}' published successfully.")
     console.print(f'Verify with: {format_list_command(channel)} --status published')
 
@@ -572,7 +578,7 @@ def do_archive(api, channel: str, notice_id: str, force: bool = False) -> None:
             return
 
     result = api.archive_notice(channel, notice_id)
-    archived_id = result.get('notice_id', notice_id)
+    archived_id = _notice_id_from_payload(result, notice_id)
     console.print(f"Notice '{archived_id}' archived successfully.")
 
 

--- a/binstar_client/mixins/notices.py
+++ b/binstar_client/mixins/notices.py
@@ -42,7 +42,7 @@ class NoticesMixin:
         return res.json()
 
     def create_notice(self, channel, message, level, expires_at):
-        """Create a draft notice (server assigns notice_id)."""
+        """Create a draft notice (server assigns id)."""
         url = f'{self.domain}/{channel}/notices'
         data, headers = jencode(
             message=message,

--- a/doc/channel_notices.md
+++ b/doc/channel_notices.md
@@ -47,7 +47,7 @@ The server assigns a UUID when you create a notice. The CLI prints the new ID on
 
 ```text
 Notice '550e8400-e29b-41d4-a716-446655440000' created successfully (draft).
-Find notice IDs with: anaconda channel notice list mychannel
+Find Notice IDs with: anaconda channel notice list mychannel
 ```
 
 Use `list` to look up IDs for existing notices. Commands that target a single notice (`get`, `update`, `publish`, `archive`, `delete`) require a valid UUID.
@@ -107,9 +107,9 @@ anaconda channel notice create mychannel \
 | `--expires-after DAYS` | Expire N days from now |
 | `--expires-at` | Exact expiry (ISO 8601, e.g. `2026-09-16T12:00:00+00:00`) |
 
-`--expires-after` and `--expires-at` are mutually exclusive. Do not send `notice_id` — the server assigns a UUID.
+`--expires-after` and `--expires-at` are mutually exclusive. Do not send `id` — the server assigns a UUID.
 
-After create, the CLI prints the server-assigned UUID and a `list` command to find notice IDs. Interactive sessions ask whether to publish immediately. Non-interactive runs also print the exact publish command to run next.
+After create, the CLI prints the server-assigned UUID and a `list` command to find Notice IDs. Interactive sessions ask whether to publish immediately. Non-interactive runs also print the exact publish command to run next.
 
 ### `update` — partial update
 

--- a/tests/test_notices.py
+++ b/tests/test_notices.py
@@ -18,7 +18,7 @@ from tests.urlmock import urlpatch
 NOTICE_UUID = '550e8400-e29b-41d4-a716-446655440000'
 
 NOTICE_ITEM = {
-    'notice_id': NOTICE_UUID,
+    'id': NOTICE_UUID,
     'owner_id': '507f1f77bcf86cd799439011',
     'message': 'hello from api',
     'level': 'info',
@@ -85,7 +85,7 @@ class TestNotices(CLITestCase):
         with self.assertRaises(UserError) as ctx:
             main(['--show-traceback', 'channel', 'notice', 'get', 'myteam', 'bad-id'])
 
-        self.assertIn('notice_id must be a valid UUID', str(ctx.exception))
+        self.assertIn('Notice ID must be a valid UUID', str(ctx.exception))
 
     @urlpatch
     def test_delete_missing_notice_id(self, urls):
@@ -93,9 +93,9 @@ class TestNotices(CLITestCase):
             with self.assertRaises(UserError) as ctx:
                 main(['--show-traceback', 'channel', 'notice', 'delete', 'myteam'])
 
-        self.assertIn("Missing argument 'NOTICE_ID'", str(ctx.exception))
+        self.assertIn("Missing argument 'Notice ID'", str(ctx.exception))
         self.assertIn('anaconda channel notice list myteam', self.stream.getvalue())
-        self.assertIn('Note: Find notice IDs with', self.stream.getvalue())
+        self.assertIn('Note: Find Notice IDs with', self.stream.getvalue())
 
     @urlpatch
     def test_create_notice(self, urls):
@@ -130,6 +130,35 @@ class TestNotices(CLITestCase):
         self.assertIn(f"Notice '{NOTICE_UUID}' created successfully", self.stream.getvalue())
         self.assertIn('anaconda channel notice list myteam', self.stream.getvalue())
         self.assertIn(f'anaconda channel notice publish myteam {NOTICE_UUID}', self.stream.getvalue())
+
+    @urlpatch
+    def test_create_notice_accepts_id_field(self, urls):
+        """API returns `id` on create."""
+        urls.register(
+            method='POST',
+            path='/myteam/notices',
+            status=201,
+            content={**NOTICE_ITEM, 'status': 'draft'},
+        )
+
+        with _patch_notice_console_print():
+            main(
+                [
+                    '--show-traceback',
+                    'channel',
+                    'notice',
+                    'create',
+                    'myteam',
+                    '--message',
+                    'hello from api',
+                    '--level',
+                    'info',
+                    '--expires-at',
+                    '2026-09-16T12:00:00+00:00',
+                ]
+            )
+
+        self.assertIn(f"Notice '{NOTICE_UUID}' created successfully", self.stream.getvalue())
 
     @urlpatch
     @freezegun.freeze_time('2026-06-01T12:00:00Z')
@@ -233,7 +262,7 @@ class TestNotices(CLITestCase):
         urls.register(
             method='POST',
             path=f'/myteam/notices/{NOTICE_UUID}/publish',
-            content={'notice_id': NOTICE_UUID, 'status': 'published'},
+            content={'id': NOTICE_UUID, 'status': 'published'},
         )
 
         with _patch_notice_console_print():
@@ -248,7 +277,7 @@ class TestNotices(CLITestCase):
         urls.register(
             method='POST',
             path=f'/myteam/notices/{NOTICE_UUID}/publish',
-            content={'notice_id': NOTICE_UUID, 'status': 'published'},
+            content={'id': NOTICE_UUID, 'status': 'published'},
         )
 
         with _patch_notice_console_print():
@@ -263,7 +292,7 @@ class TestNotices(CLITestCase):
         urls.register(
             method='POST',
             path=f'/myteam/notices/{NOTICE_UUID}/publish',
-            content={'notice_id': NOTICE_UUID, 'status': 'published'},
+            content={'id': NOTICE_UUID, 'status': 'published'},
         )
 
         with _patch_notice_console_print():
@@ -308,7 +337,7 @@ class TestNotices(CLITestCase):
         urls.register(
             method='POST',
             path=f'/myteam/notices/{NOTICE_UUID}/archive',
-            content={'notice_id': NOTICE_UUID, 'status': 'archived'},
+            content={'id': NOTICE_UUID, 'status': 'archived'},
         )
 
         with _patch_notice_console_print():
@@ -323,7 +352,7 @@ class TestNotices(CLITestCase):
         archive = urls.register(
             method='POST',
             path=f'/myorg/notices/{NOTICE_UUID}/archive',
-            content={'notice_id': NOTICE_UUID, 'status': 'archived'},
+            content={'id': NOTICE_UUID, 'status': 'archived'},
         )
 
         with _patch_notice_console_print():
@@ -339,7 +368,7 @@ class TestNotices(CLITestCase):
         publish = urls.register(
             method='POST',
             path=f'/myorg/notices/{NOTICE_UUID}/publish',
-            content={'notice_id': NOTICE_UUID, 'status': 'published'},
+            content={'id': NOTICE_UUID, 'status': 'published'},
         )
 
         with _patch_notice_console_print():
@@ -368,7 +397,7 @@ class TestNotices(CLITestCase):
         urls.register(
             method='POST',
             path=f'/myteam/notices/{NOTICE_UUID}/archive',
-            content={'notice_id': NOTICE_UUID, 'status': 'archived'},
+            content={'id': NOTICE_UUID, 'status': 'archived'},
         )
 
         with _patch_notice_console_print():
@@ -383,7 +412,7 @@ class TestNotices(CLITestCase):
         urls.register(
             method='POST',
             path=f'/myteam/notices/{NOTICE_UUID}/archive',
-            content={'notice_id': NOTICE_UUID, 'status': 'archived'},
+            content={'id': NOTICE_UUID, 'status': 'archived'},
         )
 
         with _patch_notice_console_print():
@@ -582,7 +611,7 @@ class TestNotices(CLITestCase):
         urls.register(
             method='POST',
             path=f'/myteam/notices/{NOTICE_UUID}/publish',
-            content={'notice_id': NOTICE_UUID, 'status': 'published'},
+            content={'id': NOTICE_UUID, 'status': 'published'},
         )
 
         with _patch_notice_console_print(), _patch_level_picker('info'):
@@ -677,7 +706,7 @@ class TestNotices(CLITestCase):
         deleted_item = {
             **NOTICE_ITEM,
             'status': 'deleted',
-            'notice_id': '8699dc07-c7d7-4988-be88-25ee3a2c3b10',
+            'id': '8699dc07-c7d7-4988-be88-25ee3a2c3b10',
         }
         list_req = urls.register(
             method='GET',
@@ -712,14 +741,14 @@ class TestNotices(CLITestCase):
     def test_list_notices_renders_ansi_message_safely(self, urls):
         ansi_notice = {
             **NOTICE_ITEM,
-            'notice_id': '6268dc4d-1e12-492c-9cdd-10463e998812',
+            'id': '6268dc4d-1e12-492c-9cdd-10463e998812',
             'message': '\x1b[A\x1b[A',
             'expires_at': '2032-12-12T14:52:29+00:00',
             'status': 'published',
         }
         normal_notice = {
             **NOTICE_ITEM,
-            'notice_id': '07625e4d-d844-46fa-845c-d7f91e5e561c',
+            'id': '07625e4d-d844-46fa-845c-d7f91e5e561c',
             'message': 'Updated',
             'status': 'published',
         }


### PR DESCRIPTION
## Summary
https://anaconda.atlassian.net/browse/PREX-2453

Fixes create confirmation failing with `API did not return a notice_id` even though the notice was created successfully.

The backend now returns `id` (not `notice_id`). The CLI was still looking for `notice_id`, so create succeeded on the server but the client raised an error afterward.

### Changes
- Read notice UUID from API field `id` only (create / list / get / update / publish / archive)
- User-facing copy uses **Notice ID** instead of `notice_id`
- Docs: do not send `id` on create — server assigns the UUID
- Tests updated to mock `id` responses
