### PR TITLE
HUB-3474-show_channels_shared_with_user

### DIFF
--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -217,17 +217,7 @@ def _iter_all_channels(api):
 
 
 def _add_repo_rows(table: Table, api, namespace: Optional[str]) -> None:
-    """Append anaconda.com (repocore) namespace/channel rows to the table.
-
-    Uses the flat ``GET /channels`` listing, which the server scopes to every
-    channel the user can read — including channels *shared* with them from
-    namespaces they don't own. This replaces the old per-organization
-    enumeration, which only saw the user's own namespaces and missed shares.
-    """
-    # The flat listing returns two kinds of item: top-level channels (no parent),
-    # which ARE the namespaces, and subchannels, whose parent is the namespace.
-    # A user's actual channels are the subchannels; group them under their
-    # namespace header. Preserve first-seen order so headers precede channels.
+    """Append anaconda.com (repocore) namespace/channel rows to the table."""
     namespaces: "list[str]" = []
     subchannels: "dict[str, list]" = {}
     for channel in _iter_all_channels(api):

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -218,8 +218,8 @@ def _iter_all_channels(api):
 
 def _add_repo_rows(table: Table, api, namespace: Optional[str]) -> None:
     """Append anaconda.com (repocore) namespace/channel rows to the table."""
-    namespaces: "list[str]" = []
-    subchannels: "dict[str, list]" = {}
+    namespaces: list[str] = []
+    subchannels: dict[str, list] = {}
     for channel in _iter_all_channels(api):
         if channel.parent is None:
             # A top-level channel is a namespace header, not a channel row.

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -205,33 +205,55 @@ def _upload_to_dotorg(
     upload_mod.main(args)
 
 
+def _iter_all_channels(api):
+    """Yield every channel the user can read, paging through ``GET /channels``."""
+    offset = 0
+    while True:
+        channels, total = api.list_all_channels(offset=offset, limit=_PAGE_SIZE)
+        yield from channels
+        offset += len(channels)
+        if not channels or offset >= total:
+            break
+
+
 def _add_repo_rows(table: Table, api, namespace: Optional[str]) -> None:
-    """Append anaconda.com (repocore) namespace/channel rows to the table."""
-    orgs = api.list_user_organizations()
+    """Append anaconda.com (repocore) namespace/channel rows to the table.
+
+    Uses the flat ``GET /channels`` listing, which the server scopes to every
+    channel the user can read — including channels *shared* with them from
+    namespaces they don't own. This replaces the old per-organization
+    enumeration, which only saw the user's own namespaces and missed shares.
+    """
+    # The flat listing returns two kinds of item: top-level channels (no parent),
+    # which ARE the namespaces, and subchannels, whose parent is the namespace.
+    # A user's actual channels are the subchannels; group them under their
+    # namespace header. Preserve first-seen order so headers precede channels.
+    namespaces: "list[str]" = []
+    subchannels: "dict[str, list]" = {}
+    for channel in _iter_all_channels(api):
+        if channel.parent is None:
+            # A top-level channel is a namespace header, not a channel row.
+            if channel.name not in namespaces:
+                namespaces.append(channel.name)
+        else:
+            subchannels.setdefault(channel.parent, []).append(channel)
+            if channel.parent not in namespaces:
+                # Shared channel from a namespace we don't own a header for yet.
+                namespaces.append(channel.parent)
+
     if namespace:
-        orgs = [org for org in orgs if org.name == namespace]
+        namespaces = [ns for ns in namespaces if ns == namespace]
 
-    for org in orgs:
-        table.add_row(org.name, "", "", "", "")
-
-        sub_offset = 0
-        while True:
-            try:
-                channels = api.get_channels(org.name, offset=sub_offset, limit=_PAGE_SIZE)
-            except Exception:
-                # Namespace may not have any channels yet in the repo
-                break
-            for channel in channels:
-                table.add_row(
-                    f"  {org.name}/{channel.name}",
-                    channel.privacy,
-                    channel.description,
-                    str(channel.artifact_count),
-                    str(channel.download_count),
-                )
-            if len(channels) < _PAGE_SIZE:
-                break
-            sub_offset += len(channels)
+    for ns in namespaces:
+        table.add_row(ns, "", "", "", "")
+        for channel in subchannels.get(ns, []):
+            table.add_row(
+                f"  {channel.path}",
+                channel.privacy,
+                channel.description,
+                str(channel.artifact_count),
+                str(channel.download_count),
+            )
 
 
 def _add_org_rows(table: Table, aserver_api) -> None:

--- a/binstar_client/repocore/__init__.py
+++ b/binstar_client/repocore/__init__.py
@@ -4,9 +4,7 @@ from binstar_client.repocore.client import REPO_API_PATH, AUTH_API_PATH, RepoCor
 from binstar_client.repocore.models import (
     Channel,
     ChannelCreationResponse,
-    ChannelListing,
     Namespace,
-    NamespaceChannel,
     ResolvedChannel,
 )
 
@@ -16,8 +14,6 @@ __all__ = [
     "RepoCoreClient",
     "Channel",
     "ChannelCreationResponse",
-    "ChannelListing",
     "Namespace",
-    "NamespaceChannel",
     "ResolvedChannel",
 ]

--- a/binstar_client/repocore/__init__.py
+++ b/binstar_client/repocore/__init__.py
@@ -4,6 +4,7 @@ from binstar_client.repocore.client import REPO_API_PATH, AUTH_API_PATH, RepoCor
 from binstar_client.repocore.models import (
     Channel,
     ChannelCreationResponse,
+    ChannelListing,
     Namespace,
     NamespaceChannel,
     ResolvedChannel,
@@ -15,6 +16,7 @@ __all__ = [
     "RepoCoreClient",
     "Channel",
     "ChannelCreationResponse",
+    "ChannelListing",
     "Namespace",
     "NamespaceChannel",
     "ResolvedChannel",

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -13,9 +13,7 @@ from binstar_client.repocore.errors import InvalidName, RepoCoreError, Unauthori
 from binstar_client.repocore.models import (
     Channel,
     ChannelCreationResponse,
-    ChannelListing,
     Namespace,
-    NamespaceChannel,
 )
 from binstar_client.repocore.package_utils import PackageType
 
@@ -160,11 +158,11 @@ class RepoCoreClient(BaseClient):
             response, f"removing channel {channel}", success_codes=[200, 202, 204], empty_success_codes=[200, 202, 204]
         )
 
-    def get_namespace_channel(self, channel: str) -> NamespaceChannel:
+    def get_namespace_channel(self, channel: str) -> Channel:
         url = self._get_channel_url(channel)
         response = self.get(url)
         data = self._manage_response(response, f"getting channel {channel}")
-        return NamespaceChannel(**data)
+        return Channel(**data)
 
     def update_channel(self, channel: str, **data):
         url = self._get_channel_url(channel)
@@ -175,7 +173,7 @@ class RepoCoreClient(BaseClient):
 
     def list_all_channels(
         self, offset: int = 0, limit: int = 100, include_subchannels: bool = True
-    ) -> tuple[list[ChannelListing], int]:
+    ) -> tuple[list[Channel], int]:
         """List every channel the caller can read, including channels shared with them.
 
         Hits ``GET /channels`` — the server scopes the result to the token's
@@ -192,7 +190,7 @@ class RepoCoreClient(BaseClient):
             },
         )
         data = self._manage_response(response, "listing channels")
-        items = [ChannelListing(**item) for item in data.get("items", [])]
+        items = [Channel(**item) for item in data.get("items", [])]
         return items, data.get("total_count", len(items))
 
     def get_channels(self, channel: str, offset: int = 0, limit: int = 50) -> list[Channel]:

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -13,6 +13,7 @@ from binstar_client.repocore.errors import InvalidName, RepoCoreError, Unauthori
 from binstar_client.repocore.models import (
     Channel,
     ChannelCreationResponse,
+    ChannelListing,
     Namespace,
     NamespaceChannel,
 )
@@ -171,6 +172,30 @@ class RepoCoreClient(BaseClient):
         return self._manage_response(
             response, f"updating channel {channel}", success_codes=[200, 204], empty_success_codes=[200, 204]
         )
+
+    def list_all_channels(
+        self, offset: int = 0, limit: int = 100, include_subchannels: bool = True
+    ) -> tuple[list[ChannelListing], int]:
+        """List every channel the caller can read, including channels shared with them.
+
+        Hits ``GET /channels`` — the server scopes the result to the token's
+        permissions (its own namespaces plus any channels shared with the user),
+        so a single call replaces per-namespace enumeration and surfaces shared
+        channels the organizations-based listing missed.
+
+        Returns the page of channels and the server's total count (for paging).
+        """
+        response = self.get(
+            self._channels_url,
+            params={
+                "offset": offset,
+                "limit": limit,
+                "include_subchannels": include_subchannels,
+            },
+        )
+        data = self._manage_response(response, "listing channels")
+        items = [ChannelListing(**item) for item in data.get("items", [])]
+        return items, data.get("total_count", len(items))
 
     def get_channels(self, channel: str, offset: int = 0, limit: int = 50) -> list[Channel]:
         url = join(self._channels_url, channel, "subchannels")

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -179,9 +179,7 @@ class RepoCoreClient(BaseClient):
         """List every channel the caller can read, including channels shared with them.
 
         Hits ``GET /channels`` — the server scopes the result to the token's
-        permissions (its own namespaces plus any channels shared with the user),
-        so a single call replaces per-namespace enumeration and surfaces shared
-        channels the organizations-based listing missed.
+        permissions (its own namespaces plus any channels shared with the user)
 
         Returns the page of channels and the server's total count (for paging).
         """

--- a/binstar_client/repocore/models.py
+++ b/binstar_client/repocore/models.py
@@ -27,6 +27,47 @@ class Channel(BaseModel):
     _handle_description = field_validator("description", mode="before")(_handle_none_as_empty_string)
 
 
+class ChannelListing(BaseModel):
+    """A channel as returned by the flat ``GET /channels`` listing endpoint.
+
+    Unlike :class:`Channel` (a subchannel nested under a known parent), this comes
+    from the top-level channels listing, which spans every channel the user can
+    read — including channels *shared* with them from namespaces they don't own.
+
+    A repocore "namespace" is a top-level channel named after the org; a user's
+    actual channel is a subchannel beneath it. So a channel's namespace is its
+    ``parent`` (when present); ``name`` alone is the bare channel name. ``path``
+    reconstructs the ``namespace/channel`` form used for display.
+    """
+
+    name: str
+    privacy: str
+    description: str = ""
+    artifact_count: int = 0
+    download_count: int = 0
+    parent: Optional[str] = None
+    owners: list[str] = Field(default_factory=list)
+
+    _handle_description = field_validator("description", mode="before")(_handle_none_as_empty_string)
+
+    @field_validator("owners", mode="before")
+    @classmethod
+    def _filter_none_owners(cls, v):
+        if v is None:
+            return []
+        return [o for o in v if o]
+
+    @property
+    def namespace(self) -> Optional[str]:
+        """The channel's namespace: its parent top-level channel, if any."""
+        return self.parent
+
+    @property
+    def path(self) -> str:
+        """The ``namespace/channel`` display path (or bare name for a top-level channel)."""
+        return f"{self.parent}/{self.name}" if self.parent else self.name
+
+
 class NamespaceChannel(BaseModel):
     """Parent namespace channel data from the repo API."""
 

--- a/binstar_client/repocore/models.py
+++ b/binstar_client/repocore/models.py
@@ -16,23 +16,13 @@ class Namespace(BaseModel):
 
 
 class Channel(BaseModel):
-    """Channel within a parent namespace channel."""
+    """A repocore channel, as returned by any of the channel endpoints.
 
-    name: str
-    privacy: str
-    description: str = ""
-    artifact_count: int = 0
-    download_count: int = 0
-
-    _handle_description = field_validator("description", mode="before")(_handle_none_as_empty_string)
-
-
-class ChannelListing(BaseModel):
-    """A channel as returned by the flat ``GET /channels`` listing endpoint.
-
-    Unlike :class:`Channel` (a subchannel nested under a known parent), this comes
-    from the top-level channels listing, which spans every channel the user can
-    read — including channels *shared* with them from namespaces they don't own.
+    The repo API serializes channels with a single shape (``resources.channels``
+    ``dump()``); the various endpoints — the flat ``GET /channels`` listing, a
+    parent's ``/subchannels``, and a single ``GET /channels/{name}`` — differ only
+    in which of those fields they populate. This model carries the superset with
+    permissive defaults, so one class parses every channel response.
 
     A repocore "namespace" is a top-level channel named after the org; a user's
     actual channel is a subchannel beneath it. So a channel's namespace is its
@@ -45,6 +35,11 @@ class ChannelListing(BaseModel):
     description: str = ""
     artifact_count: int = 0
     download_count: int = 0
+    mirror_count: int = 0
+    channel_count: int = 0
+    indexing_behavior: str = "default"
+    created: str = ""
+    updated: str = ""
     parent: Optional[str] = None
     owners: list[str] = Field(default_factory=list)
 
@@ -66,31 +61,6 @@ class ChannelListing(BaseModel):
     def path(self) -> str:
         """The ``namespace/channel`` display path (or bare name for a top-level channel)."""
         return f"{self.parent}/{self.name}" if self.parent else self.name
-
-
-class NamespaceChannel(BaseModel):
-    """Parent namespace channel data from the repo API."""
-
-    name: str
-    privacy: str
-    description: str = ""
-    artifact_count: int = 0
-    download_count: int = 0
-    mirror_count: int = 0
-    channel_count: int = 0
-    indexing_behavior: str = "default"
-    created: str = ""
-    updated: str = ""
-    owners: list[str] = Field(default_factory=list)
-
-    _handle_description = field_validator("description", mode="before")(_handle_none_as_empty_string)
-
-    @field_validator("owners", mode="before")
-    @classmethod
-    def _filter_none_owners(cls, v):
-        if v is None:
-            return []
-        return [o for o in v if o]
 
 
 class ChannelCreationResponse(BaseModel):

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -9,6 +9,7 @@ from typer.testing import CliRunner
 from binstar_client.repocore import (
     Channel,
     ChannelCreationResponse,
+    ChannelListing,
     Namespace,
     NamespaceChannel,
     RepoCoreClient,
@@ -174,6 +175,33 @@ class TestRepoCoreClientAPI:
         result = client.list_user_organizations()
         assert result == []
         assert isinstance(result, list)
+
+    def test_list_all_channels(self):
+        client = _make_client()
+        payload = {
+            "total_count": 2,
+            "items": [
+                {"name": "myorg", "privacy": "public"},
+                {"name": "dev", "privacy": "private", "parent": "myorg", "artifact_count": 3},
+            ],
+        }
+        mock_response = _mock_response(200, payload)
+        client.get = MagicMock(return_value=mock_response)
+
+        items, total = client.list_all_channels()
+
+        assert total == 2
+        assert all(isinstance(ch, ChannelListing) for ch in items)
+        # The flat listing hits /channels with include_subchannels so shared
+        # channels (subchannels under namespaces the user doesn't own) come back.
+        call_url = client.get.call_args[0][0]
+        assert call_url.endswith("/api/repo/channels")
+        assert client.get.call_args[1]["params"]["include_subchannels"] is True
+        # A subchannel's namespace is its parent; path reconstructs namespace/channel.
+        assert items[0].namespace is None
+        assert items[0].path == "myorg"
+        assert items[1].namespace == "myorg"
+        assert items[1].path == "myorg/dev"
 
     def test_create_channel(self):
         client = _make_client()
@@ -542,18 +570,19 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [
-            Namespace(name="main"),
-        ]
-        mock_api.get_channels.return_value = [
-            Channel(
-                name="dev",
-                privacy="public",
-                description="",
-                artifact_count=10,
-                download_count=5,
-            )
-        ]
+        mock_api.list_all_channels.return_value = (
+            [
+                ChannelListing(name="main", privacy="public"),
+                ChannelListing(
+                    name="dev",
+                    privacy="public",
+                    parent="main",
+                    artifact_count=10,
+                    download_count=5,
+                ),
+            ],
+            2,
+        )
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["list"])
@@ -566,19 +595,15 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [
-            Namespace(name="org-a"),
-            Namespace(name="org-b"),
-        ]
-        mock_api.get_channel_subchannels.return_value = [
-            Channel(
-                name="dev",
-                privacy="public",
-                description="",
-                artifact_count=5,
-                download_count=1,
-            )
-        ]
+        mock_api.list_all_channels.return_value = (
+            [
+                ChannelListing(name="org-a", privacy="public"),
+                ChannelListing(name="org-b", privacy="public"),
+                ChannelListing(name="dev", privacy="public", parent="org-a"),
+                ChannelListing(name="prod", privacy="public", parent="org-b"),
+            ],
+            4,
+        )
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["list", "--namespace", "org-a"])
@@ -587,51 +612,40 @@ class TestRepoCoreChannelsCLI:
         assert "org-a" in result.output
         assert "org-b" not in result.output
 
-    def test_channels_list_fetches_subchannels_per_org(self):
+    def test_channels_list_includes_shared_channels(self):
+        """A channel shared from a namespace the user doesn't own still appears.
+
+        The flat listing returns the shared subchannel (parent=someorg) without a
+        top-level channel of its own; its namespace header is synthesized so the
+        shared channel is grouped and shown.
+        """
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [
-            Namespace(name="org-a"),
-            Namespace(name="org-b"),
-        ]
-        mock_api.get_channels.side_effect = [
+        mock_api.list_all_channels.return_value = (
             [
-                Channel(
-                    name="dev",
-                    privacy="private",
-                    description="",
-                    artifact_count=3,
-                    download_count=1,
-                )
+                ChannelListing(name="myorg", privacy="public"),
+                ChannelListing(name="dev", privacy="private", parent="myorg"),
+                # Shared with the user from an org they don't own (no top-level item).
+                ChannelListing(name="staging", privacy="public", parent="someorg"),
             ],
-            [
-                Channel(
-                    name="staging",
-                    privacy="public",
-                    description="Staging",
-                    artifact_count=7,
-                    download_count=2,
-                )
-            ],
-        ]
+            3,
+        )
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["list"])
 
         assert result.exit_code == 0
-        assert "org-a" in result.output
-        assert "org-b" in result.output
+        assert "myorg" in result.output
         assert "dev" in result.output
+        assert "someorg" in result.output
         assert "staging" in result.output
-        assert mock_api.get_channels.call_count == 2
 
     def test_channels_list_source_repo_skips_org(self):
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="org-a")]
-        mock_api.get_channels.return_value = []
+        mock_api.list_all_channels.return_value = ([ChannelListing(name="org-a", privacy="public")], 1)
 
         with (
             _patch_repo_api(mock_api),
@@ -675,8 +689,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="org-a")]
-        mock_api.get_channels.return_value = []
+        mock_api.list_all_channels.return_value = ([ChannelListing(name="org-a", privacy="public")], 1)
 
         aserver = MagicMock()
         aserver.user.side_effect = Exception("not logged in")

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -9,9 +9,7 @@ from typer.testing import CliRunner
 from binstar_client.repocore import (
     Channel,
     ChannelCreationResponse,
-    ChannelListing,
     Namespace,
-    NamespaceChannel,
     RepoCoreClient,
     ResolvedChannel,
 )
@@ -36,7 +34,7 @@ class TestPydanticModels:
         assert ch.artifact_count == 0
 
     def test_namespace_channel_model(self):
-        nsch = NamespaceChannel(name="myorg/dev", privacy="private", owners=["user1", None, "user2"])
+        nsch = Channel(name="myorg/dev", privacy="private", owners=["user1", None, "user2"])
         assert nsch.name == "myorg/dev"
         assert nsch.owners == ["user1", "user2"]
         assert nsch.indexing_behavior == "default"
@@ -97,7 +95,7 @@ class TestPydanticModels:
         mock_response = _mock_response(200, channel)
         client.get = MagicMock(return_value=mock_response)
         result = client.get_namespace_channel("myorg/dev")
-        assert isinstance(result, NamespaceChannel)
+        assert isinstance(result, Channel)
         assert result.name == "myorg/dev"
 
     def test_resolved_channel_model_used_in_resolve_namespace_and_channel(self):
@@ -191,7 +189,7 @@ class TestRepoCoreClientAPI:
         items, total = client.list_all_channels()
 
         assert total == 2
-        assert all(isinstance(ch, ChannelListing) for ch in items)
+        assert all(isinstance(ch, Channel) for ch in items)
         # The flat listing hits /channels with include_subchannels so shared
         # channels (subchannels under namespaces the user doesn't own) come back.
         call_url = client.get.call_args[0][0]
@@ -248,7 +246,7 @@ class TestRepoCoreClientAPI:
         client.get = MagicMock(return_value=mock_response)
 
         result = client.get_namespace_channel("test")
-        assert isinstance(result, NamespaceChannel)
+        assert isinstance(result, Channel)
         assert result.name == "test"
         assert result.privacy == "public"
         assert result.artifact_count == 5
@@ -572,8 +570,8 @@ class TestRepoCoreChannelsCLI:
         mock_api = MagicMock()
         mock_api.list_all_channels.return_value = (
             [
-                ChannelListing(name="main", privacy="public"),
-                ChannelListing(
+                Channel(name="main", privacy="public"),
+                Channel(
                     name="dev",
                     privacy="public",
                     parent="main",
@@ -597,10 +595,10 @@ class TestRepoCoreChannelsCLI:
         mock_api = MagicMock()
         mock_api.list_all_channels.return_value = (
             [
-                ChannelListing(name="org-a", privacy="public"),
-                ChannelListing(name="org-b", privacy="public"),
-                ChannelListing(name="dev", privacy="public", parent="org-a"),
-                ChannelListing(name="prod", privacy="public", parent="org-b"),
+                Channel(name="org-a", privacy="public"),
+                Channel(name="org-b", privacy="public"),
+                Channel(name="dev", privacy="public", parent="org-a"),
+                Channel(name="prod", privacy="public", parent="org-b"),
             ],
             4,
         )
@@ -624,10 +622,10 @@ class TestRepoCoreChannelsCLI:
         mock_api = MagicMock()
         mock_api.list_all_channels.return_value = (
             [
-                ChannelListing(name="myorg", privacy="public"),
-                ChannelListing(name="dev", privacy="private", parent="myorg"),
+                Channel(name="myorg", privacy="public"),
+                Channel(name="dev", privacy="private", parent="myorg"),
                 # Shared with the user from an org they don't own (no top-level item).
-                ChannelListing(name="staging", privacy="public", parent="someorg"),
+                Channel(name="staging", privacy="public", parent="someorg"),
             ],
             3,
         )
@@ -645,7 +643,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = ([ChannelListing(name="org-a", privacy="public")], 1)
+        mock_api.list_all_channels.return_value = ([Channel(name="org-a", privacy="public")], 1)
 
         with (
             _patch_repo_api(mock_api),
@@ -689,7 +687,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = ([ChannelListing(name="org-a", privacy="public")], 1)
+        mock_api.list_all_channels.return_value = ([Channel(name="org-a", privacy="public")], 1)
 
         aserver = MagicMock()
         aserver.user.side_effect = Exception("not logged in")
@@ -906,7 +904,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.get_channel.return_value = NamespaceChannel(
+        mock_api.get_channel.return_value = Channel(
             name="dev",
             privacy="private",
             description="",


### PR DESCRIPTION
Repocore shared channels need an additional URL param but support showing all (sub)channels a user has out the box. This PR just modified anaconda-client to use that existing feature.