### PR TITLE
HUB_3498-windows_unicode_fix_for_chan_list

### DIFF
--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -27,10 +27,15 @@ from binstar_client.repocore.resolve import (
     resolve_no_namespace as _resolve_no_namespace,
 )
 from binstar_client.utils import get_server_api
+from binstar_client.utils.console_utils import configure_console_encoding
 
 __all__ = ["app", "_resolve_namespace_and_channel", "_resolve_no_namespace", "_resolve_channels_with_namespaces"]
 
 logger = logging.getLogger("binstar.channel")
+
+# Ensure Rich box-drawing borders render on Windows legacy code pages instead of
+# being emitted as escaped \uXXXX literals (see console_utils for details).
+configure_console_encoding()
 
 # Value shown in a column where the concept does not exist for that source.
 # anaconda.org labels have no namespace and no channel-level privacy.

--- a/binstar_client/scripts/cli.py
+++ b/binstar_client/scripts/cli.py
@@ -21,6 +21,7 @@ from binstar_client import commands
 from binstar_client import errors
 from binstar_client.commands.login import interactive_login
 from binstar_client.utils import logging_utils
+from binstar_client.utils.console_utils import configure_console_encoding
 
 
 logger = logging.getLogger('binstar')
@@ -260,6 +261,12 @@ def main(
     allow_plugin_main: bool = True,
 ) -> None:
     """Entrypoint for CLI interface of `anaconda`."""
+    # Make sure Rich-rendered tables (e.g. `anaconda channel list`) print their
+    # box-drawing borders correctly on Windows legacy code pages, rather than as
+    # escaped \uXXXX literals. Runs before any command output regardless of
+    # whether we delegate to a plugin main or the standalone path.
+    configure_console_encoding()
+
     if allow_plugin_main and (not os.environ.get('ANACONDA_CLIENT_FORCE_STANDALONE', '')):
         plugged_in_main: typing.Optional[typing.Callable[[], typing.Any]] = _load_main_plugin()
         if plugged_in_main is not None:

--- a/binstar_client/utils/console_utils.py
+++ b/binstar_client/utils/console_utils.py
@@ -2,19 +2,11 @@
 
 """Console/terminal helpers shared across CLI commands.
 
-The main entry point here is :func:`configure_console_encoding`, which works
-around a Windows-specific rendering problem: ``anaconda channel list`` (and any
-other Rich-rendered table) prints its box-drawing borders as raw escaped Unicode
-literals (``\\u250f``, ``\\u2501``, ...) instead of the actual characters
-(``┏``, ``━``, ...).
-
-Root cause: Rich writes Unicode box-drawing characters straight to
-``sys.stdout``. On Windows the interpreter's standard streams frequently default
-to a legacy code page (e.g. ``cp1252``) that cannot represent those characters.
-When such a stream is configured with the ``backslashreplace`` error handler,
-the box characters are silently turned into their ``\\uXXXX`` escape sequences
-rather than raising or rendering. Reconfiguring the streams to UTF-8 makes the
-characters encode correctly, matching the clean output seen on macOS/Linux.
+Rich writes Unicode box-drawing borders straight to ``sys.stdout``. On Windows
+the standard streams often use a legacy code page (e.g. ``cp1252``) that can't
+represent them, so with the ``backslashreplace`` error handler they render as
+escaped ``\\uXXXX`` literals instead of characters like ``┏━┳``. Reconfiguring
+the streams to UTF-8 fixes this, matching macOS/Linux output.
 """
 
 from __future__ import annotations
@@ -28,16 +20,9 @@ _configured = False
 
 
 def configure_console_encoding() -> None:
-    """Ensure the standard streams can render Unicode box-drawing characters.
+    """Reconfigure Windows stdout/stderr to UTF-8 so Rich borders render.
 
-    On Windows the standard streams may use a non-UTF-8 code page, which causes
-    Rich table borders to be emitted as escaped ``\\uXXXX`` literals. This
-    reconfigures ``stdout``/``stderr`` to UTF-8 so those characters render
-    correctly. It is a no-op on non-Windows platforms, when the stream is
-    already UTF-8, and on any stream that does not support reconfiguration
-    (e.g. a redirected pipe wrapped in something without ``reconfigure``).
-
-    Safe to call multiple times; the work is performed at most once.
+    No-op off Windows and safe to call multiple times; runs its work at most once.
     """
     global _configured
     if _configured:
@@ -52,11 +37,10 @@ def configure_console_encoding() -> None:
 
 
 def _reconfigure_stream_to_utf8(stream: object) -> None:
-    """Best-effort switch of a single text stream to UTF-8 output.
+    """Switch a single text stream to UTF-8, ignoring streams that can't.
 
-    Any failure is swallowed: an unwritable or non-reconfigurable stream should
-    never take down the CLI. Worst case, output falls back to the prior
-    (possibly mangled) behavior rather than raising.
+    A non-reconfigurable or detached stream must never take down the CLI, so
+    failures fall back to prior behavior rather than raising.
     """
     if not isinstance(stream, io.TextIOWrapper):
         return
@@ -65,11 +49,6 @@ def _reconfigure_stream_to_utf8(stream: object) -> None:
         return
 
     try:
-        # ``backslashreplace`` keeps output from ever crashing on a character
-        # the (now UTF-8) stream still can't encode, while UTF-8 itself covers
-        # the full box-drawing range.
         stream.reconfigure(encoding='utf-8', errors='backslashreplace')
     except (ValueError, OSError):
-        # ValueError: stream detached / does not support reconfigure.
-        # OSError: underlying handle rejected the change.
         pass

--- a/binstar_client/utils/console_utils.py
+++ b/binstar_client/utils/console_utils.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+
+"""Console/terminal helpers shared across CLI commands.
+
+The main entry point here is :func:`configure_console_encoding`, which works
+around a Windows-specific rendering problem: ``anaconda channel list`` (and any
+other Rich-rendered table) prints its box-drawing borders as raw escaped Unicode
+literals (``\\u250f``, ``\\u2501``, ...) instead of the actual characters
+(``┏``, ``━``, ...).
+
+Root cause: Rich writes Unicode box-drawing characters straight to
+``sys.stdout``. On Windows the interpreter's standard streams frequently default
+to a legacy code page (e.g. ``cp1252``) that cannot represent those characters.
+When such a stream is configured with the ``backslashreplace`` error handler,
+the box characters are silently turned into their ``\\uXXXX`` escape sequences
+rather than raising or rendering. Reconfiguring the streams to UTF-8 makes the
+characters encode correctly, matching the clean output seen on macOS/Linux.
+"""
+
+from __future__ import annotations
+
+__all__ = ('configure_console_encoding',)
+
+import io
+import sys
+
+_configured = False
+
+
+def configure_console_encoding() -> None:
+    """Ensure the standard streams can render Unicode box-drawing characters.
+
+    On Windows the standard streams may use a non-UTF-8 code page, which causes
+    Rich table borders to be emitted as escaped ``\\uXXXX`` literals. This
+    reconfigures ``stdout``/``stderr`` to UTF-8 so those characters render
+    correctly. It is a no-op on non-Windows platforms, when the stream is
+    already UTF-8, and on any stream that does not support reconfiguration
+    (e.g. a redirected pipe wrapped in something without ``reconfigure``).
+
+    Safe to call multiple times; the work is performed at most once.
+    """
+    global _configured
+    if _configured:
+        return
+    _configured = True
+
+    if sys.platform != 'win32':
+        return
+
+    for stream in (sys.stdout, sys.stderr):
+        _reconfigure_stream_to_utf8(stream)
+
+
+def _reconfigure_stream_to_utf8(stream: object) -> None:
+    """Best-effort switch of a single text stream to UTF-8 output.
+
+    Any failure is swallowed: an unwritable or non-reconfigurable stream should
+    never take down the CLI. Worst case, output falls back to the prior
+    (possibly mangled) behavior rather than raising.
+    """
+    if not isinstance(stream, io.TextIOWrapper):
+        return
+
+    if (getattr(stream, 'encoding', '') or '').lower().replace('-', '') == 'utf8':
+        return
+
+    try:
+        # ``backslashreplace`` keeps output from ever crashing on a character
+        # the (now UTF-8) stream still can't encode, while UTF-8 itself covers
+        # the full box-drawing range.
+        stream.reconfigure(encoding='utf-8', errors='backslashreplace')
+    except (ValueError, OSError):
+        # ValueError: stream detached / does not support reconfigure.
+        # OSError: underlying handle rejected the change.
+        pass

--- a/tests/test_console_utils.py
+++ b/tests/test_console_utils.py
@@ -11,34 +11,30 @@ import binstar_client.utils.console_utils as console_utils
 
 @pytest.fixture(autouse=True)
 def _reset_configured_flag(monkeypatch):
-    # configure_console_encoding does its work only once; reset the module-level
-    # guard so each test exercises it fresh.
+    # The work runs at most once per process; reset the guard so each test is fresh.
     monkeypatch.setattr(console_utils, "_configured", False)
 
 
-def _make_stream(encoding):
-    return io.TextIOWrapper(io.BytesIO(), encoding=encoding, errors="backslashreplace")
+def _install_streams(monkeypatch, platform, encoding, cls=io.TextIOWrapper):
+    monkeypatch.setattr(console_utils.sys, "platform", platform)
+    stdout = cls(io.BytesIO(), encoding=encoding, errors="backslashreplace")
+    stderr = cls(io.BytesIO(), encoding=encoding, errors="backslashreplace")
+    monkeypatch.setattr(console_utils.sys, "stdout", stdout)
+    monkeypatch.setattr(console_utils.sys, "stderr", stderr)
+    return stdout, stderr
 
 
-def test_no_op_on_non_windows(monkeypatch):
-    monkeypatch.setattr(console_utils.sys, "platform", "linux")
-
-    stream = _make_stream("cp1252")
-    monkeypatch.setattr(console_utils.sys, "stdout", stream)
-    monkeypatch.setattr(console_utils.sys, "stderr", stream)
+def test_leaves_streams_alone_off_windows(monkeypatch):
+    stdout, stderr = _install_streams(monkeypatch, "linux", "cp1252")
 
     console_utils.configure_console_encoding()
 
-    assert stream.encoding == "cp1252"
+    assert stdout.encoding == "cp1252"
+    assert stderr.encoding == "cp1252"
 
 
-def test_reconfigures_streams_on_windows(monkeypatch):
-    monkeypatch.setattr(console_utils.sys, "platform", "win32")
-
-    stdout = _make_stream("cp1252")
-    stderr = _make_stream("cp1252")
-    monkeypatch.setattr(console_utils.sys, "stdout", stdout)
-    monkeypatch.setattr(console_utils.sys, "stderr", stderr)
+def test_reconfigures_both_streams_on_windows(monkeypatch):
+    stdout, stderr = _install_streams(monkeypatch, "win32", "cp1252")
 
     console_utils.configure_console_encoding()
 
@@ -46,71 +42,23 @@ def test_reconfigures_streams_on_windows(monkeypatch):
     assert stderr.encoding == "utf-8"
 
 
-def test_box_characters_encode_after_reconfigure(monkeypatch):
-    """The box-drawing chars that broke on Windows now round-trip as UTF-8."""
-    monkeypatch.setattr(console_utils.sys, "platform", "win32")
-
-    raw = io.BytesIO()
-    stream = io.TextIOWrapper(raw, encoding="cp1252", errors="backslashreplace")
-    monkeypatch.setattr(console_utils.sys, "stdout", stream)
-    monkeypatch.setattr(console_utils.sys, "stderr", stream)
+def test_box_characters_round_trip_after_reconfigure(monkeypatch):
+    """The bug's payoff: box-drawing chars encode instead of becoming \\uXXXX."""
+    stdout, _ = _install_streams(monkeypatch, "win32", "cp1252")
 
     console_utils.configure_console_encoding()
+    stdout.write("┏━┳┓")
+    stdout.flush()
 
-    stream.write("┏━┳┓")
-    stream.flush()
-
-    assert raw.getvalue().decode("utf-8") == "┏━┳┓"
-
-
-def test_already_utf8_stream_untouched(monkeypatch):
-    monkeypatch.setattr(console_utils.sys, "platform", "win32")
-
-    calls = []
-
-    class Stream(io.TextIOWrapper):
-        def reconfigure(self, *args, **kwargs):  # pragma: no cover - should not run
-            calls.append((args, kwargs))
-
-    stream = Stream(io.BytesIO(), encoding="utf-8")
-    monkeypatch.setattr(console_utils.sys, "stdout", stream)
-    monkeypatch.setattr(console_utils.sys, "stderr", stream)
-
-    console_utils.configure_console_encoding()
-
-    assert calls == []
+    assert stdout.buffer.getvalue().decode("utf-8") == "┏━┳┓"
 
 
-def test_reconfigure_failure_is_swallowed(monkeypatch):
-    monkeypatch.setattr(console_utils.sys, "platform", "win32")
-
-    class Stream(io.TextIOWrapper):
+def test_survives_non_reconfigurable_stream(monkeypatch):
+    class Stubborn(io.TextIOWrapper):
         def reconfigure(self, *args, **kwargs):
             raise OSError("cannot reconfigure")
 
-    stream = Stream(io.BytesIO(), encoding="cp1252")
-    monkeypatch.setattr(console_utils.sys, "stdout", stream)
-    monkeypatch.setattr(console_utils.sys, "stderr", stream)
+    _install_streams(monkeypatch, "win32", "cp1252", cls=Stubborn)
 
-    # Must not raise.
+    # A stream that refuses reconfiguration must not crash the CLI.
     console_utils.configure_console_encoding()
-
-
-def test_runs_only_once(monkeypatch):
-    monkeypatch.setattr(console_utils.sys, "platform", "win32")
-
-    calls = []
-
-    class Stream(io.TextIOWrapper):
-        def reconfigure(self, *args, **kwargs):
-            calls.append(1)
-
-    stream = Stream(io.BytesIO(), encoding="cp1252")
-    monkeypatch.setattr(console_utils.sys, "stdout", stream)
-    monkeypatch.setattr(console_utils.sys, "stderr", stream)
-
-    console_utils.configure_console_encoding()
-    first = len(calls)
-    console_utils.configure_console_encoding()
-
-    assert len(calls) == first

--- a/tests/test_console_utils.py
+++ b/tests/test_console_utils.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for binstar_client.utils.console_utils."""
+
+import io
+
+import pytest
+
+import binstar_client.utils.console_utils as console_utils
+
+
+@pytest.fixture(autouse=True)
+def _reset_configured_flag(monkeypatch):
+    # configure_console_encoding does its work only once; reset the module-level
+    # guard so each test exercises it fresh.
+    monkeypatch.setattr(console_utils, "_configured", False)
+
+
+def _make_stream(encoding):
+    return io.TextIOWrapper(io.BytesIO(), encoding=encoding, errors="backslashreplace")
+
+
+def test_no_op_on_non_windows(monkeypatch):
+    monkeypatch.setattr(console_utils.sys, "platform", "linux")
+
+    stream = _make_stream("cp1252")
+    monkeypatch.setattr(console_utils.sys, "stdout", stream)
+    monkeypatch.setattr(console_utils.sys, "stderr", stream)
+
+    console_utils.configure_console_encoding()
+
+    assert stream.encoding == "cp1252"
+
+
+def test_reconfigures_streams_on_windows(monkeypatch):
+    monkeypatch.setattr(console_utils.sys, "platform", "win32")
+
+    stdout = _make_stream("cp1252")
+    stderr = _make_stream("cp1252")
+    monkeypatch.setattr(console_utils.sys, "stdout", stdout)
+    monkeypatch.setattr(console_utils.sys, "stderr", stderr)
+
+    console_utils.configure_console_encoding()
+
+    assert stdout.encoding == "utf-8"
+    assert stderr.encoding == "utf-8"
+
+
+def test_box_characters_encode_after_reconfigure(monkeypatch):
+    """The box-drawing chars that broke on Windows now round-trip as UTF-8."""
+    monkeypatch.setattr(console_utils.sys, "platform", "win32")
+
+    raw = io.BytesIO()
+    stream = io.TextIOWrapper(raw, encoding="cp1252", errors="backslashreplace")
+    monkeypatch.setattr(console_utils.sys, "stdout", stream)
+    monkeypatch.setattr(console_utils.sys, "stderr", stream)
+
+    console_utils.configure_console_encoding()
+
+    stream.write("┏━┳┓")
+    stream.flush()
+
+    assert raw.getvalue().decode("utf-8") == "┏━┳┓"
+
+
+def test_already_utf8_stream_untouched(monkeypatch):
+    monkeypatch.setattr(console_utils.sys, "platform", "win32")
+
+    calls = []
+
+    class Stream(io.TextIOWrapper):
+        def reconfigure(self, *args, **kwargs):  # pragma: no cover - should not run
+            calls.append((args, kwargs))
+
+    stream = Stream(io.BytesIO(), encoding="utf-8")
+    monkeypatch.setattr(console_utils.sys, "stdout", stream)
+    monkeypatch.setattr(console_utils.sys, "stderr", stream)
+
+    console_utils.configure_console_encoding()
+
+    assert calls == []
+
+
+def test_reconfigure_failure_is_swallowed(monkeypatch):
+    monkeypatch.setattr(console_utils.sys, "platform", "win32")
+
+    class Stream(io.TextIOWrapper):
+        def reconfigure(self, *args, **kwargs):
+            raise OSError("cannot reconfigure")
+
+    stream = Stream(io.BytesIO(), encoding="cp1252")
+    monkeypatch.setattr(console_utils.sys, "stdout", stream)
+    monkeypatch.setattr(console_utils.sys, "stderr", stream)
+
+    # Must not raise.
+    console_utils.configure_console_encoding()
+
+
+def test_runs_only_once(monkeypatch):
+    monkeypatch.setattr(console_utils.sys, "platform", "win32")
+
+    calls = []
+
+    class Stream(io.TextIOWrapper):
+        def reconfigure(self, *args, **kwargs):
+            calls.append(1)
+
+    stream = Stream(io.BytesIO(), encoding="cp1252")
+    monkeypatch.setattr(console_utils.sys, "stdout", stream)
+    monkeypatch.setattr(console_utils.sys, "stderr", stream)
+
+    console_utils.configure_console_encoding()
+    first = len(calls)
+    console_utils.configure_console_encoding()
+
+    assert len(calls) == first


### PR DESCRIPTION
Fixes windows encoding issue for CLI display. Channel list was showing escaped unicode literals.